### PR TITLE
Feature: added display for elapsed/remaining track time

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -19,6 +19,11 @@ export default function Settings({ onOpenDonationModal }) {
     return storedValue !== null ? storedValue === "true" : true;
   });
 
+  const [elapsedTimeEnabled, setElapsedTimeEnabled] = useState(() => {
+    const storedValue = localStorage.getItem("elapsedTimeEnabled");
+    return storedValue !== null ? storedValue === "true" : true;
+  })
+
   useEffect(() => {
     localStorage.setItem(
       "trackNameScrollingEnabled",
@@ -31,11 +36,18 @@ export default function Settings({ onOpenDonationModal }) {
   }, [lyricsMenuEnabled]);
 
   useEffect(() => {
+    localStorage.setItem("elapsedTimeEnabled", elapsedTimeEnabled.toString());
+  }, [elapsedTimeEnabled]);
+
+  useEffect(() => {
     if (localStorage.getItem("trackNameScrollingEnabled") === null) {
       localStorage.setItem("trackNameScrollingEnabled", "true");
     }
     if (localStorage.getItem("lyricsMenuEnabled") === null) {
       localStorage.setItem("lyricsMenuEnabled", "true");
+    }
+    if (localStorage.getItem("elapsedTimeEnabled") === null) {
+      localStorage.setItem("elapsedTimeEnabled", "true");
     }
   }, []);
 
@@ -123,6 +135,28 @@ export default function Settings({ onOpenDonationModal }) {
           </Field>
           <p className="pt-4 text-[28px] font-[560] text-white/60 max-w-[380px] tracking-tight">
             Enable or disable the lyrics menu option in the player.
+          </p>
+        </div>
+        <div>
+          <Field className="flex items-center">
+            <Switch
+              checked={elapsedTimeEnabled}
+              onChange={setElapsedTimeEnabled}
+              className="group relative inline-flex h-11 w-20 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none data-[checked]:bg-white/40"
+            >
+              <span
+                aria-hidden="true"
+                className="pointer-events-none inline-block h-10 w-10 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out group-data-[checked]:translate-x-9"
+              />
+            </Switch>
+            <Label as="span" className="ml-3 text-sm">
+              <span className="text-[32px] font-[580] text-white tracking-tight">
+                Show Time Elapsed
+              </span>
+            </Label>
+          </Field>
+          <p className="pt-4 text-[28px] font-[560] text-white/60 max-w-[380px] tracking-tight">
+            Display the elapsed track time or remaining track time below the progress bar.
           </p>
         </div>
         <div className="relative">

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -53,6 +53,7 @@ const NowPlaying = ({
   const containerWidth = 380;
   const scrollSpeed = 40;
   const [shouldScroll, setShouldScroll] = useState(false);
+  const [elapsedTimeEnabled, setElapsedTimeEnabled] = useState(true);
 
   useEffect(() => {
     if (currentPlayback && currentPlayback.item) {
@@ -193,6 +194,7 @@ const NowPlaying = ({
   useEffect(() => {
     const scrollingEnabled = localStorage.getItem("trackNameScrollingEnabled");
     const lyricsMenuEnabled = localStorage.getItem("lyricsMenuEnabled");
+    const elapsedTimeEnabled = localStorage.getItem("elapsedTimeEnabled");
 
     if (scrollingEnabled === null) {
       localStorage.setItem("trackNameScrollingEnabled", "true");
@@ -207,6 +209,14 @@ const NowPlaying = ({
     } else {
       setlyricsMenuOptionEnabled(lyricsMenuEnabled === "true");
     }
+
+    if (elapsedTimeEnabled === null) {
+      localStorage.setItem("elapsedTimeEnabled", "true");
+      setElapsedTimeEnabled(true);
+    } else {
+      setElapsedTimeEnabled(elapsedTimeEnabled === "true");
+    }
+
   }, []);
 
   useEffect(() => {
@@ -536,6 +546,23 @@ const NowPlaying = ({
       addTrackToPlaylistAPI(selectedPlaylistId);
     }
   };
+
+  const convertTimeToLength = (ms, elapsed) => {
+    let totalSeconds = Math.floor(ms / 1000);
+
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const formattedMinutes = minutes.toString().padStart(2, '0');
+    const formattedSeconds = seconds.toString().padStart(2, '0');
+
+    if (hours > 0) {
+      return `${!elapsed ? "-" : ""}${hours}:${formattedMinutes}:${formattedSeconds}`;
+    }
+
+    return `${!elapsed ? "-" : ""}${formattedMinutes}:${formattedSeconds}`;
+  }
 
   useEffect(() => {
     if (currentPlayback) {
@@ -932,7 +959,7 @@ const NowPlaying = ({
           onClick={() => setOpen(false)}
         />
       )}
-      <div className="flex flex-col gap-4 h-screen w-full z-10 fadeIn-animation">
+      <div className="flex flex-col gap-3 h-screen w-full z-10 fadeIn-animation">
         <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
           <div className="min-w-[280px] mr-8">
             <LongPressLink
@@ -943,8 +970,8 @@ const NowPlaying = ({
               <Image
                 src={albumArt || "/images/not-playing.webp"}
                 alt="Album Art"
-                width={280}
-                height={280}
+                width={260}
+                height={260}
                 priority
                 className="aspect-square rounded-[12px] drop-shadow-xl"
               />
@@ -966,7 +993,8 @@ const NowPlaying = ({
                         trackNameScrollingEnabled && shouldScroll
                           ? "animate-scroll"
                           : ""
-                      }`}
+                        }`
+                      }
                     >
                       {trackName}
                     </h4>
@@ -990,7 +1018,7 @@ const NowPlaying = ({
               </LongPressLink>
             </div>
           ) : (
-            <div className="flex-1 flex flex-col h-[280px]">
+            <div className="flex-1 flex flex-col h-[260px]">
               <div
                 className="flex-1 text-left overflow-y-auto h-[280px] w-[380px]"
                 ref={lyricsContainerRef}
@@ -1031,7 +1059,18 @@ const NowPlaying = ({
           </div>
         </div>
 
-        <div className="flex justify-between items-center w-full px-12 mt-4">
+        <div className="w-full px-12 overflow-hidden">
+          <div className="flex justify-between">
+            { currentPlayback && currentPlayback.item
+                ? <><span className="text-white/60 text-[24px]">{elapsedTimeEnabled ? convertTimeToLength((currentPlayback.progress_ms), true) : convertTimeToLength((currentPlayback.item.duration_ms - currentPlayback.progress_ms), false)}</span>
+                <span className="text-white/60 text-[24px]">{convertTimeToLength(currentPlayback.item.duration_ms, true)}</span></>
+                : <><span className="text-white/60 text-[24px]">--:--</span>
+                <span className="text-white/60 text-[24px]">--:--</span></>
+            }
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center w-full px-12">
           <div className="flex-shrink-0" onClick={toggleLikeTrack}>
             {isLiked ? (
               <StarIconFilled className="w-14 h-14" />


### PR DESCRIPTION
This feature shows the current progress of the track formatted to HH:MM:SS below the progress bar. It supports showing the elapsed time and remaining track time left.

<details>
<summary>Screenshots</summary>

## New setting added.
![image](https://github.com/user-attachments/assets/f6f01f3e-e564-44a1-b158-6612830b9ccd)  

## Now playing page with elapsed time displayed.
![image](https://github.com/user-attachments/assets/315c53b7-0bc2-44b9-b4bb-dedebe83be90)  

## Had to make the album cover and lyric box element 20px shorter.
![image](https://github.com/user-attachments/assets/53841a91-cfce-45a3-a1e5-2a5393294d11)  

## Also includes support for media longer than an hour (plus remaining time on display).
![image](https://github.com/user-attachments/assets/9473c0a3-073e-45b6-ba5f-6ad1767a3e37)

</details>