### PR TITLE
Feature: added display for elapsed/remaining track time

### DIFF
--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -24,6 +24,11 @@ export default function Settings({ onOpenDonationModal }) {
     return storedValue !== null ? storedValue === "true" : false;
   });
 
+  const [elapsedTimeEnabled, setElapsedTimeEnabled] = useState(() => {
+    const storedValue = localStorage.getItem("elapsedTimeEnabled");
+    return storedValue !== null ? storedValue === "true" : true;
+  })
+
   useEffect(() => {
     localStorage.setItem(
       "trackNameScrollingEnabled",
@@ -40,6 +45,10 @@ export default function Settings({ onOpenDonationModal }) {
   }, [autoRedirectEnabled]);
 
   useEffect(() => {
+    localStorage.setItem("elapsedTimeEnabled", elapsedTimeEnabled.toString());
+  }, [elapsedTimeEnabled]);
+
+  useEffect(() => {
     if (localStorage.getItem("trackNameScrollingEnabled") === null) {
       localStorage.setItem("trackNameScrollingEnabled", "true");
     }
@@ -48,6 +57,9 @@ export default function Settings({ onOpenDonationModal }) {
     }
     if (localStorage.getItem("autoRedirectEnabled") === null) {
       localStorage.setItem("autoRedirectEnabled", "false");
+    }
+    if (localStorage.getItem("elapsedTimeEnabled") === null) {
+      localStorage.setItem("elapsedTimeEnabled", "true");
     }
   }, []);
 
@@ -158,6 +170,28 @@ export default function Settings({ onOpenDonationModal }) {
           <p className="pt-4 text-[28px] font-[560] text-white/60 max-w-[380px] tracking-tight">
             Automatically redirect to the Now Playing screen after one minute of
             inactivity.
+          </p>
+        </div>
+        <div>
+          <Field className="flex items-center">
+            <Switch
+              checked={elapsedTimeEnabled}
+              onChange={setElapsedTimeEnabled}
+              className="group relative inline-flex h-11 w-20 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none data-[checked]:bg-white/40"
+            >
+              <span
+                aria-hidden="true"
+                className="pointer-events-none inline-block h-10 w-10 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out group-data-[checked]:translate-x-9"
+              />
+            </Switch>
+            <Label as="span" className="ml-3 text-sm">
+              <span className="text-[32px] font-[580] text-white tracking-tight">
+                Show Time Elapsed
+              </span>
+            </Label>
+          </Field>
+          <p className="pt-4 text-[28px] font-[560] text-white/60 max-w-[380px] tracking-tight">
+            Display the elapsed track time or remaining track time below the progress bar.
           </p>
         </div>
         <div className="relative">

--- a/src/hooks/useElapsedTime.js
+++ b/src/hooks/useElapsedTime.js
@@ -1,0 +1,20 @@
+import { useState, useEffect, useRef } from "react";
+
+export function useElapsedTime() {
+  const [elapsedTimeEnabled, setElapsedTimeEnabled] =
+  useState(true);
+
+  useEffect(() => {
+    const elapsedTimeEnabled = localStorage.getItem("elapsedTimeEnabled");
+    if (elapsedTimeEnabled === null) {
+      localStorage.setItem("elapsedTimeEnabled", "true");
+      setElapsedTimeEnabled(true);
+    } else {
+      setElapsedTimeEnabled(elapsedTimeEnabled === "true");
+    }
+  }, []);
+
+  return {
+    elapsedTimeEnabled
+  };
+}

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -25,6 +25,7 @@ import { useTrackScroll } from "@/hooks/useTrackScroll";
 import { usePlaybackControls } from "@/hooks/usePlaybackControls";
 import { usePlaylistDialog } from "@/hooks/usePlaylistDialog";
 import { useAppState } from "@/hooks/useAppState";
+import { useElapsedTime } from "@/hooks/useElapsedTime";
 
 import {
   HeartIcon,
@@ -118,6 +119,8 @@ export default function NowPlaying({
   const { trackNameScrollingEnabled, shouldScroll, trackNameRef } =
     useTrackScroll(trackName);
 
+  const { elapsedTimeEnabled } = useElapsedTime();
+
   const artistName = currentPlayback?.item
     ? currentPlayback.item.type === "episode"
       ? currentPlayback.item.show.name
@@ -156,6 +159,25 @@ export default function NowPlaying({
     };
   };
 
+  const convertTimeToLength = (ms, elapsed) => {
+    let totalSeconds = Math.floor(ms / 1000);
+
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const formattedMinutes = minutes.toString().padStart(2, '0');
+    const formattedSeconds = seconds.toString().padStart(2, '0');
+
+    if (hours > 0) {
+      return `${!elapsed ? "-" : ""}${hours}:${formattedMinutes}:${formattedSeconds}`;
+    }
+
+    return `${!elapsed ? "-" : ""}${formattedMinutes}:${formattedSeconds}`;
+  }
+
+
+
   const PlayPauseButton = () =>
     isPlaying ? (
       <PauseIcon className="w-14 h-14" />
@@ -172,7 +194,7 @@ export default function NowPlaying({
 
   return (
     <>
-      <div className="flex flex-col gap-4 h-screen w-full z-10 fadeIn-animation">
+      <div className="flex flex-col gap-3 h-screen w-full z-10 fadeIn-animation">
         <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
           <div className="min-w-[280px] mr-8">
             <LongPressLink
@@ -195,8 +217,8 @@ export default function NowPlaying({
                     ? "Podcast Cover"
                     : "Album Art"
                 }
-                width={280}
-                height={280}
+                width={260}
+                height={260}
                 priority
                 className="aspect-square rounded-[12px] drop-shadow-xl"
               />
@@ -257,9 +279,9 @@ export default function NowPlaying({
               </LongPressLink>
             </div>
           ) : (
-            <div className="flex-1 flex flex-col h-[280px]">
+            <div className="flex-1 flex flex-col h-[260px]">
               <div
-                className="flex-1 text-left overflow-y-auto h-[280px] w-[380px]"
+                className="flex-1 text-left overflow-y-auto h-[260px] w-[380px]"
                 ref={lyricsContainerRef}
               >
                 {isLoadingLyrics ? (
@@ -304,7 +326,18 @@ export default function NowPlaying({
           />
         </div>
 
-        <div className="flex justify-between items-center w-full px-12 mt-4">
+        <div className="w-full px-12 overflow-hidden">
+          <div className="flex justify-between">
+            { currentPlayback && currentPlayback.item
+                ? <><span className="text-white/60 text-[24px]">{elapsedTimeEnabled ? convertTimeToLength((currentPlayback.progress_ms), true) : convertTimeToLength((currentPlayback.item.duration_ms - currentPlayback.progress_ms), false)}</span>
+                <span className="text-white/60 text-[24px]">{convertTimeToLength(currentPlayback.item.duration_ms, true)}</span></>
+                : <><span className="text-white/60 text-[24px]">--:--</span>
+                <span className="text-white/60 text-[24px]">--:--</span></>
+            }
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center w-full px-12">
           <div className="flex-shrink-0" onClick={toggleLikeTrack}>
             {isLiked ? (
               <HeartIconFilled className="w-14 h-14" />

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -166,15 +166,17 @@ export default function NowPlaying({
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
 
-    const formattedMinutes = minutes.toString().padStart(2, '0');
-    const formattedSeconds = seconds.toString().padStart(2, '0');
+    const formattedMinutes = minutes.toString().padStart(2, "0");
+    const formattedSeconds = seconds.toString().padStart(2, "0");
 
     if (hours > 0) {
-      return `${!elapsed ? "-" : ""}${hours}:${formattedMinutes}:${formattedSeconds}`;
+      return `${
+        !elapsed ? "-" : ""
+      }${hours}:${formattedMinutes}:${formattedSeconds}`;
     }
 
     return `${!elapsed ? "-" : ""}${formattedMinutes}:${formattedSeconds}`;
-  }
+  };
 
   const PlayPauseButton = () =>
     isPlaying ? (
@@ -192,7 +194,7 @@ export default function NowPlaying({
 
   return (
     <>
-      <div className="flex flex-col gap-3 h-screen w-full z-10 fadeIn-animation">
+      <div className="flex flex-col gap-1 h-screen w-full z-10 fadeIn-animation">
         <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
           <div className="min-w-[280px] mr-8">
             <LongPressLink
@@ -215,8 +217,8 @@ export default function NowPlaying({
                     ? "Podcast Cover"
                     : "Album Art"
                 }
-                width={260}
-                height={260}
+                width={280}
+                height={280}
                 priority
                 className="aspect-square rounded-[12px] drop-shadow-xl"
               />
@@ -277,9 +279,9 @@ export default function NowPlaying({
               </LongPressLink>
             </div>
           ) : (
-            <div className="flex-1 flex flex-col h-[260px]">
+            <div className="flex-1 flex flex-col h-[280px]">
               <div
-                className="flex-1 text-left overflow-y-auto h-[260px] w-[380px]"
+                className="flex-1 text-left overflow-y-auto h-[280px] w-[380px]"
                 ref={lyricsContainerRef}
               >
                 {isLoadingLyrics ? (
@@ -316,7 +318,7 @@ export default function NowPlaying({
           )}
         </div>
 
-        <div className="px-12">
+        <div className={`px-12 ${!elapsedTimeEnabled ? "pb-7 pt-3" : ""}`}>
           <ProgressBar
             progress={progress}
             isPlaying={isPlaying}
@@ -324,16 +326,30 @@ export default function NowPlaying({
           />
         </div>
 
-        <div className="w-full px-12 overflow-hidden">
-          <div className="flex justify-between">
-            { currentPlayback && currentPlayback.item
-                ? <><span className="text-white/60 text-[24px]">{elapsedTimeEnabled ? convertTimeToLength((currentPlayback.progress_ms), true) : convertTimeToLength((currentPlayback.item.duration_ms - currentPlayback.progress_ms), false)}</span>
-                <span className="text-white/60 text-[24px]">{convertTimeToLength(currentPlayback.item.duration_ms, true)}</span></>
-                : <><span className="text-white/60 text-[24px]">--:--</span>
-                <span className="text-white/60 text-[24px]">--:--</span></>
-            }
+        {elapsedTimeEnabled && (
+          <div className="w-full px-12 pb-1.5 pt-1.5 -mb-1.5 overflow-hidden">
+            <div className="flex justify-between">
+              {currentPlayback && currentPlayback.item ? (
+                <>
+                  <span className="text-white/60 text-[20px]">
+                    {convertTimeToLength(currentPlayback.progress_ms, true)}
+                  </span>
+                  <span className="text-white/60 text-[20px]">
+                    {convertTimeToLength(
+                      currentPlayback.item.duration_ms,
+                      true
+                    )}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="text-white/60 text-[20px]">--:--</span>
+                  <span className="text-white/60 text-[20px]">--:--</span>
+                </>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="flex justify-between items-center w-full px-12">
           <div className="flex-shrink-0" onClick={toggleLikeTrack}>

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -176,8 +176,6 @@ export default function NowPlaying({
     return `${!elapsed ? "-" : ""}${formattedMinutes}:${formattedSeconds}`;
   }
 
-
-
   const PlayPauseButton = () =>
     isPlaying ? (
       <PauseIcon className="w-14 h-14" />


### PR DESCRIPTION
Redoing #72 to make my changes based off of `main`.

This feature shows the current progress of the track formatted to HH:MM:SS below the progress bar. It supports showing the elapsed time and remaining track time left.

<details>
<summary>Screenshots</summary>

## New setting added.
![image](https://github.com/user-attachments/assets/f6f01f3e-e564-44a1-b158-6612830b9ccd)  

## Now playing page with elapsed time displayed.
![image](https://github.com/user-attachments/assets/315c53b7-0bc2-44b9-b4bb-dedebe83be90)  

## Had to make the album cover and lyric box element 20px shorter.
![image](https://github.com/user-attachments/assets/53841a91-cfce-45a3-a1e5-2a5393294d11)  

## Also includes support for media longer than an hour (plus remaining time on display).
![image](https://github.com/user-attachments/assets/9473c0a3-073e-45b6-ba5f-6ad1767a3e37)

</details>