### PR TITLE
fix network check to work correctly

### DIFF
--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -77,7 +77,7 @@ const ConnectionScreen = () => {
               if (isConnected) {
                 clearInterval(networkCheckInterval);
                 if (hasStoredCredentials) {
-                  window.location.reload();
+                  router.push("/");
                 }
               }
             }, 5000);

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -7,7 +7,7 @@ import PairingScreen from "../bluetooth/PairingScreen";
 import EnableTetheringScreen from "../bluetooth/EnableTetheringScreen";
 import { NocturneIcon } from "../icons";
 
-import { checkNetworkConnectivity, waitForNetwork } from "../../lib/networkChecker";
+import { checkNetworkConnectivity } from "../../lib/networkChecker";
 
 const ConnectionScreen = () => {
   const [isBluetoothDiscovering, setIsBluetoothDiscovering] = useState(false);
@@ -15,6 +15,7 @@ const ConnectionScreen = () => {
   const [pairingKey, setPairingKey] = useState(null);
   const [showTethering, setShowTethering] = useState(false);
   const [deviceType, setDeviceType] = useState(null);
+  // const [isNetworkConnected, setIsNetworkConnected] = useState(false);
   
   const hasStoredCredentials = typeof window !== 'undefined' && (
     localStorage.getItem("spotifyRefreshToken") || 
@@ -77,7 +78,7 @@ const ConnectionScreen = () => {
               if (isConnected) {
                 clearInterval(networkCheckInterval);
                 if (hasStoredCredentials) {
-                  router.push("/");
+                  window.location.reload();
                 }
               }
             }, 5000);
@@ -101,16 +102,6 @@ const ConnectionScreen = () => {
   useEffect(() => {
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     setDeviceType(isIOS ? "ios" : "other");
-
-    const networkCheckInterval = setInterval(async () => {
-      const isConnected = await checkNetworkConnectivity();
-      if (isConnected) {
-        clearInterval(networkCheckInterval);
-        if (hasStoredCredentials) {
-          router.push("/");
-        }
-      }
-    }, 1000);
 
     const ws = new WebSocket("ws://localhost:5000/ws");
 

--- a/src/lib/networkChecker.js
+++ b/src/lib/networkChecker.js
@@ -21,9 +21,6 @@ export async function checkNetworkConnectivity() {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
-        throw new NetworkError("Authorization error");
-      }
       throw new NetworkError(`HTTP error! status: ${response.status}`);
     }
 

--- a/src/lib/networkChecker.js
+++ b/src/lib/networkChecker.js
@@ -5,22 +5,15 @@ export class NetworkError extends Error {
   }
 }
 
-export async function checkNetworkConnectivity(accessToken) {
-  if (!accessToken) {
-    throw new NetworkError("No access token available");
-  }
-
+export async function checkNetworkConnectivity() {
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     const response = await fetch(
-      "https://api.spotify.com/v1/me/player/devices",
+      "https://api.spotify.com/v1/",
       {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
+        method: "OPTIONS",
         signal: controller.signal,
       }
     );
@@ -35,11 +28,7 @@ export async function checkNetworkConnectivity(accessToken) {
     }
 
     return {
-      isConnected: true,
-      hasDevices: async () => {
-        const data = await response.json();
-        return data.devices && data.devices.length > 0;
-      },
+      isConnected: true
     };
   } catch (error) {
     if (error.name === "AbortError") {
@@ -55,7 +44,6 @@ export async function checkNetworkConnectivity(accessToken) {
 }
 
 export async function waitForNetwork(
-  accessToken,
   maxAttempts = 3,
   delayMs = 2000
 ) {
@@ -63,7 +51,7 @@ export async function waitForNetwork(
 
   while (attempts < maxAttempts) {
     try {
-      const status = await checkNetworkConnectivity(accessToken);
+      const status = await checkNetworkConnectivity();
       return status;
     } catch (error) {
       attempts++;
@@ -75,12 +63,12 @@ export async function waitForNetwork(
   }
 }
 
-export function startNetworkMonitoring(accessToken, onStatusChange) {
+export function startNetworkMonitoring(onStatusChange) {
   let isOnline = true;
 
   const checkConnection = async () => {
     try {
-      await checkNetworkConnectivity(accessToken);
+      await checkNetworkConnectivity();
       if (!isOnline) {
         isOnline = true;
         onStatusChange?.(true);

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -155,7 +155,7 @@ export default function App({ Component, pageProps }) {
         try {
           const savedAccessToken = localStorage.getItem("spotifyAccessToken");
           if (savedAccessToken) {
-            await checkNetworkConnectivity(savedAccessToken);
+            await checkNetworkConnectivity();
           } else {
             await fetch("https://api.spotify.com/v1", { method: "OPTIONS" });
           }
@@ -301,11 +301,10 @@ export default function App({ Component, pageProps }) {
       );
 
       const networkCleanup = startNetworkMonitoring(
-        accessToken,
         async (isConnected) => {
           try {
             if (isConnected) {
-              const status = await checkNetworkConnectivity(accessToken);
+              const status = await checkNetworkConnectivity();
               setNetworkStatus({ isConnected: true });
             } else {
               setNetworkStatus({ isConnected: false });

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -153,12 +153,7 @@ export default function App({ Component, pageProps }) {
       }
       const intervalId = setInterval(async () => {
         try {
-          const savedAccessToken = localStorage.getItem("spotifyAccessToken");
-          if (savedAccessToken) {
-            await checkNetworkConnectivity();
-          } else {
-            await fetch("https://api.spotify.com/v1", { method: "OPTIONS" });
-          }
+          await checkNetworkConnectivity();
           clearInterval(intervalId);
           setNetworkStatus({ isConnected: true });
         } catch (error) {
@@ -207,9 +202,7 @@ export default function App({ Component, pageProps }) {
       if (typeof window === "undefined") return;
 
       try {
-        await checkNetworkConnectivity(
-          localStorage.getItem("spotifyAccessToken")
-        );
+        await checkNetworkConnectivity();
       } catch (error) {
         setAuthState({
           authSelectionMade: false,


### PR DESCRIPTION
changes:
- uses OPTIONS on /v1 instead of GET on /v1/devices, allows for network check to work when token is expired
- remove duplicate network check in authselection.jsx
- remove need for access token in network check, caused network check to not work correctly if expired
- removed some unused stuff relating to network check

probably could be a lot better, since i've never used js before