### PR TITLE
Feature: add swiping gestures to Now Playing

### DIFF
--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -145,6 +145,24 @@ export default function Settings({ accessToken, onOpenDonationModal }) {
           storageKey: "remainingTimeEnabled",
           defaultValue: false,
         },
+        {
+          id: "song-change-gesture",
+          title: "Swipe to Change Song",
+          type: "toggle",
+          description:
+            "Enable left/right swipe gestures to skip to the previous or next song.",
+          storageKey: "songChangeGestureEnabled",
+          defaultValue: true,
+        },
+        {
+          id: "show-lyrics-gesture",
+          title: "Swipe to Show Lyrics",
+          type: "toggle",
+          description:
+            "Enable swiping up on the track info to show the lyrics of a song.",
+          storageKey: "showLyricsGestureEnabled",
+          defaultValue: false,
+        },
       ],
     },
     account: {

--- a/src/hooks/useNowPlaying.js
+++ b/src/hooks/useNowPlaying.js
@@ -6,6 +6,8 @@ export function useNowPlaying({
   accessToken,
   currentPlayback,
   fetchCurrentPlayback,
+  showLyrics,
+  handleToggleLyrics,
   handleError,
   showBrightnessOverlay,
   drawerOpen,
@@ -164,15 +166,20 @@ export function useNowPlaying({
       const dx = endPosition.x - startTouchPosition.x;
       const dy = endPosition.y - startTouchPosition.y;
 
-      if (Math.abs(dx) > Math.abs(dy)) {
-        if (dx > 0) { //swipe right
-          skipToPrevious();
-        } else { //swipe left
-          skipToNext();
+      // handleError("epic", `dx: ${dx} | dy: ${dy}`);
+      if (Math.abs(dx) > 30 && Math.abs(dx) > Math.abs(dy)) {
+          if (dx > 0) { //swipe right
+            skipToPrevious();
+          } else { //swipe left
+            skipToNext();
+          }
+      } else if(Math.abs(dy) > 18 && Math.abs(dy) > Math.abs(dx)) {
+        if(dy < 0 && !showLyrics) {
+          handleToggleLyrics();
         }
       }
     }, 
-    [startTouchPosition]
+    [startTouchPosition, currentPlayback, showLyrics]
   );
 
   const checkIfTrackIsLiked = useCallback(

--- a/src/hooks/useNowPlaying.js
+++ b/src/hooks/useNowPlaying.js
@@ -17,6 +17,8 @@ export function useNowPlaying({
   const [volume, setVolume] = useState(null);
   const [isVolumeVisible, setIsVolumeVisible] = useState(false);
   const [startTouchPosition, setStartTouchPosition] = useState({ x: 0, y: 0 });
+  const [songChangeGestureEnabled, setSongChangeGestureEnabled] = useState(true);
+  const [showLyricsGestureEnabled, setShowLyricsGestureEnabled] = useState(false);
   const volumeTimeoutRef = useRef(null);
   const volumeSyncIntervalRef = useRef(null);
   const previousTrackId = useRef(null);
@@ -166,13 +168,13 @@ export function useNowPlaying({
       const dx = endPosition.x - startTouchPosition.x;
       const dy = endPosition.y - startTouchPosition.y;
 
-      if (Math.abs(dx) > 30 && Math.abs(dx) > Math.abs(dy)) {
-          if (dx > 0) { //swipe right
-            skipToPrevious();
-          } else { //swipe left
-            skipToNext();
-          }
-      } else if(Math.abs(dy) > 18 && Math.abs(dy) > Math.abs(dx)) {
+      if (songChangeGestureEnabled === "true" && Math.abs(dx) > 30 && Math.abs(dx) > Math.abs(dy)) {
+        if (dx > 0) { //swipe right
+          skipToPrevious();
+        } else { //swipe left
+          skipToNext();
+        }
+      } else if(showLyricsGestureEnabled === "true" && Math.abs(dy) > 18 && Math.abs(dy) > Math.abs(dx)) {
         if(dy < 0 && !showLyrics) {
           handleToggleLyrics();
         }
@@ -233,6 +235,25 @@ export function useNowPlaying({
       console.error("Error toggling like track:", error);
     }
   };
+
+  useEffect(() => {
+    const songChangeGestureEnabledValue = localStorage.getItem("songChangeGestureEnabled");
+    const showLyricsGestureEnabledValue = localStorage.getItem("showLyricsGestureEnabled");
+
+    if (songChangeGestureEnabledValue === null) {
+      localStorage.setItem("songChangeGestureEnabled", "true");
+      setSongChangeGestureEnabled(true);
+    } else {
+      setSongChangeGestureEnabled(songChangeGestureEnabledValue);
+    }
+
+    if(showLyricsGestureEnabledValue === null) {
+      localStorage.setItem("showLyricsGestureEnabled", "false");
+      setShowLyricsGestureEnabled(false);
+    } else {
+      setShowLyricsGestureEnabled(showLyricsGestureEnabledValue);
+    }
+  }, []);
 
   useEffect(() => {
     if (currentPlayback && currentPlayback.item) {

--- a/src/hooks/useNowPlaying.js
+++ b/src/hooks/useNowPlaying.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, use } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/router";
 import { getCurrentDevice } from "@/services/deviceService";
 

--- a/src/hooks/useNowPlaying.js
+++ b/src/hooks/useNowPlaying.js
@@ -166,7 +166,6 @@ export function useNowPlaying({
       const dx = endPosition.x - startTouchPosition.x;
       const dy = endPosition.y - startTouchPosition.y;
 
-      // handleError("epic", `dx: ${dx} | dy: ${dy}`);
       if (Math.abs(dx) > 30 && Math.abs(dx) > Math.abs(dy)) {
           if (dx > 0) { //swipe right
             skipToPrevious();

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -78,6 +78,8 @@ export default function NowPlaying({
     changeVolume,
     toggleLikeTrack,
     handleWheelScroll,
+    handleTouchStart,
+    handleTouchEnd
   } = useNowPlaying({
     accessToken,
     currentPlayback,
@@ -122,31 +124,6 @@ export default function NowPlaying({
 
   const { elapsedTimeEnabled, remainingTimeEnabled, showTimeDisplay } =
     useElapsedTime();
-
-    const [startPosition, setStartPosition] = useState({ x: 0, y: 0 });
-
-    const handleTouchStart = (event) => {
-      const touch = event.touches[0];
-      setStartPosition({ x: touch.clientX, y: touch.clientY });
-    };
-  
-    const handleTouchEnd = (event) => {
-      if(showLyrics || !currentPlayback) return;
-
-      const touch = event.changedTouches[0];
-      const endPosition = { x: touch.clientX, y: touch.clientY };
-  
-      const dx = endPosition.x - startPosition.x;
-      const dy = endPosition.y - startPosition.y;
-  
-      if (Math.abs(dx) > Math.abs(dy)) {
-        if (dx > 0) {
-          skipToPrevious();
-        } else {
-          skipToNext();
-        }
-      }
-    };
 
   const artistName = currentPlayback?.item
     ? currentPlayback.item.type === "episode"
@@ -222,7 +199,7 @@ export default function NowPlaying({
   return (
     <>
       <div className="flex flex-col gap-1 h-screen w-full z-10 fadeIn-animation">
-        <div id="touchArea" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+        <div onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
           <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
             <div className="min-w-[280px] mr-8">
               <LongPressLink
@@ -346,7 +323,7 @@ export default function NowPlaying({
               </div>
             </div>
           )}
-        </div>
+          </div>
         </div>
 
         <div className={`px-12 ${!showTimeDisplay ? "pb-7 pt-3" : ""}`}>

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -69,6 +69,17 @@ export default function NowPlaying({
   const [isDeviceSwitcherOpen, setIsDeviceSwitcherOpen] = useState(false);
 
   const {
+    showLyrics,
+    parsedLyrics,
+    currentLyricIndex,
+    isLoadingLyrics,
+    lyricsUnavailable,
+    lyricsMenuOptionEnabled,
+    lyricsContainerRef,
+    handleToggleLyrics,
+  } = useLyrics({ currentPlayback });
+
+  const {
     isLiked,
     volume,
     isVolumeVisible,
@@ -84,21 +95,12 @@ export default function NowPlaying({
     accessToken,
     currentPlayback,
     fetchCurrentPlayback,
+    showLyrics,
+    handleToggleLyrics,
     handleError,
     showBrightnessOverlay,
     drawerOpen,
   });
-
-  const {
-    showLyrics,
-    parsedLyrics,
-    currentLyricIndex,
-    isLoadingLyrics,
-    lyricsUnavailable,
-    lyricsMenuOptionEnabled,
-    lyricsContainerRef,
-    handleToggleLyrics,
-  } = useLyrics({ currentPlayback });
 
   const { isShuffled, repeatMode, toggleShuffle, toggleRepeat } =
     usePlaybackControls({

--- a/src/pages/now-playing.jsx
+++ b/src/pages/now-playing.jsx
@@ -123,6 +123,31 @@ export default function NowPlaying({
   const { elapsedTimeEnabled, remainingTimeEnabled, showTimeDisplay } =
     useElapsedTime();
 
+    const [startPosition, setStartPosition] = useState({ x: 0, y: 0 });
+
+    const handleTouchStart = (event) => {
+      const touch = event.touches[0];
+      setStartPosition({ x: touch.clientX, y: touch.clientY });
+    };
+  
+    const handleTouchEnd = (event) => {
+      if(showLyrics || !currentPlayback) return;
+
+      const touch = event.changedTouches[0];
+      const endPosition = { x: touch.clientX, y: touch.clientY };
+  
+      const dx = endPosition.x - startPosition.x;
+      const dy = endPosition.y - startPosition.y;
+  
+      if (Math.abs(dx) > Math.abs(dy)) {
+        if (dx > 0) {
+          skipToPrevious();
+        } else {
+          skipToNext();
+        }
+      }
+    };
+
   const artistName = currentPlayback?.item
     ? currentPlayback.item.type === "episode"
       ? currentPlayback.item.show.name
@@ -197,39 +222,9 @@ export default function NowPlaying({
   return (
     <>
       <div className="flex flex-col gap-1 h-screen w-full z-10 fadeIn-animation">
-        <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
-          <div className="min-w-[280px] mr-8">
-            <LongPressLink
-              href={
-                !currentPlayback ? "" 
-                : currentPlayback?.item?.type === "episode"
-                  ? `/show/${currentPlayback.item.show.id}`
-                  : `/album/${currentPlayback?.item?.album?.id}`
-              }
-              spotifyUrl={
-                currentPlayback?.item?.type === "episode"
-                  ? currentPlayback.item.show.external_urls?.spotify
-                  : currentPlayback?.item?.album?.external_urls?.spotify
-              }
-              accessToken={accessToken}
-            >
-              <Image
-                src={albumArt}
-                alt={
-                  currentPlayback?.item?.type === "episode"
-                    ? "Podcast Cover"
-                    : "Album Art"
-                }
-                width={280}
-                height={280}
-                priority
-                className="aspect-square rounded-[12px] drop-shadow-xl"
-              />
-            </LongPressLink>
-          </div>
-
-          {!showLyrics || !currentPlayback?.item ? (
-            <div className="flex-1 text-center md:text-left">
+        <div id="touchArea" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+          <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
+            <div className="min-w-[280px] mr-8">
               <LongPressLink
                 href={
                   !currentPlayback ? "" 
@@ -244,61 +239,92 @@ export default function NowPlaying({
                 }
                 accessToken={accessToken}
               >
-                {trackNameScrollingEnabled ? (
-                  <div className="track-name-container">
-                    <h4
-                      ref={trackNameRef}
-                      key={currentPlayback?.item?.id || "not-playing"}
-                      className={`track-name text-[40px] font-[580] text-white tracking-tight whitespace-nowrap ${
-                        trackNameScrollingEnabled && shouldScroll
-                          ? "animate-scroll"
-                          : ""
-                      }`}
-                    >
-                      {trackName}
-                    </h4>
-                  </div>
-                ) : (
-                  <h4 className="text-[40px] font-[580] text-white truncate tracking-tight max-w-[400px]">
-                    {trackName}
-                  </h4>
-                )}
-              </LongPressLink>
-              <LongPressLink
-                href={
-                  currentPlayback?.item?.type === "episode"
-                    ? `/show/${currentPlayback.item.show.id}`
-                    : `/artist/${currentPlayback?.item?.artists[0]?.id}`
-                }
-                spotifyUrl={
-                  currentPlayback?.item?.type === "episode"
-                    ? currentPlayback.item.show.external_urls?.spotify
-                    : currentPlayback?.item?.artists[0]?.external_urls?.spotify
-                }
-                accessToken={accessToken}
-              >
-                <h4 className="text-[36px] font-[560] text-white/60 truncate tracking-tight max-w-[380px]">
-                  {artistName}
-                </h4>
+                <Image
+                  src={albumArt}
+                  alt={
+                    currentPlayback?.item?.type === "episode"
+                      ? "Podcast Cover"
+                      : "Album Art"
+                  }
+                  width={280}
+                  height={280}
+                  priority
+                  className="aspect-square rounded-[12px] drop-shadow-xl"
+                />
               </LongPressLink>
             </div>
-          ) : (
-            <div className="flex-1 flex flex-col h-[280px]">
-              <div
-                className="flex-1 text-left overflow-y-auto h-[280px] w-[380px]"
-                ref={lyricsContainerRef}
-              >
-                {isLoadingLyrics ? (
-                  <p className="text-white text-[40px] font-[580] tracking-tight transition-colors duration-300">
-                    Loading lyrics...
-                  </p>
-                ) : parsedLyrics.length > 0 ? (
-                  parsedLyrics.map((lyric, index) => {
-                    const { className } = getTextStyles(lyric.text);
-                    const conditionalClass =
-                      index === currentLyricIndex
-                        ? "text-white"
-                        : index === currentLyricIndex - 1 ||
+
+            {!showLyrics || !currentPlayback?.item ? (
+              <div className="flex-1 text-center md:text-left">
+                <LongPressLink
+                  href={
+                    !currentPlayback ? "" 
+                    : currentPlayback?.item?.type === "episode"
+                      ? `/show/${currentPlayback.item.show.id}`
+                      : `/album/${currentPlayback?.item?.album?.id}`
+                  }
+                  spotifyUrl={
+                    currentPlayback?.item?.type === "episode"
+                      ? currentPlayback.item.show.external_urls?.spotify
+                      : currentPlayback?.item?.album?.external_urls?.spotify
+                  }
+                  accessToken={accessToken}
+                >
+                  {trackNameScrollingEnabled ? (
+                    <div className="track-name-container">
+                      <h4
+                        ref={trackNameRef}
+                        key={currentPlayback?.item?.id || "not-playing"}
+                        className={`track-name text-[40px] font-[580] text-white tracking-tight whitespace-nowrap ${
+                          trackNameScrollingEnabled && shouldScroll
+                            ? "animate-scroll"
+                            : ""
+                        }`}
+                      >
+                        {trackName}
+                      </h4>
+                    </div>
+                  ) : (
+                    <h4 className="text-[40px] font-[580] text-white truncate tracking-tight max-w-[400px]">
+                      {trackName}
+                    </h4>
+                  )}
+                </LongPressLink>
+                <LongPressLink
+                  href={
+                    currentPlayback?.item?.type === "episode"
+                      ? `/show/${currentPlayback.item.show.id}`
+                      : `/artist/${currentPlayback?.item?.artists[0]?.id}`
+                  }
+                  spotifyUrl={
+                    currentPlayback?.item?.type === "episode"
+                      ? currentPlayback.item.show.external_urls?.spotify
+                      : currentPlayback?.item?.artists[0]?.external_urls?.spotify
+                  }
+                  accessToken={accessToken}
+                >
+                  <h4 className="text-[36px] font-[560] text-white/60 truncate tracking-tight max-w-[380px]">
+                    {artistName}
+                  </h4>
+                </LongPressLink>
+              </div>
+            ) : (
+              <div className="flex-1 flex flex-col h-[280px]">
+                <div
+                  className="flex-1 text-left overflow-y-auto h-[280px] w-[380px]"
+                  ref={lyricsContainerRef}
+                >
+                  {isLoadingLyrics ? (
+                    <p className="text-white text-[40px] font-[580] tracking-tight transition-colors duration-300">
+                      Loading lyrics...
+                    </p>
+                  ) : parsedLyrics.length > 0 ? (
+                    parsedLyrics.map((lyric, index) => {
+                      const { className } = getTextStyles(lyric.text);
+                      const conditionalClass =
+                        index === currentLyricIndex
+                          ? "text-white"
+                          : index === currentLyricIndex - 1 ||
                           index === currentLyricIndex + 1
                         ? "text-white/40"
                         : "text-white/40";
@@ -320,6 +346,7 @@ export default function NowPlaying({
               </div>
             </div>
           )}
+        </div>
         </div>
 
         <div className={`px-12 ${!showTimeDisplay ? "pb-7 pt-3" : ""}`}>


### PR DESCRIPTION
This feature will add swiping gestures to the Now Playing page.

- Swiping **right** will go to the previous song (or restart the song from the beginning).
- Swiping **left** will go to the next song.
- Swiping **up** will show the lyrics (only if the lyrics aren't being displayed already).
  - Left/Right swipes will still work even if the lyrics are showing.

There's a swipe threshold so that tiny, tiny swipes don't trigger these gestures. For the left/right swipes, the swipe needs to be at least 30px wide. For the up swipe, the swipe needs to be at least 18px wide.

Here's a small demo video:
https://github.com/user-attachments/assets/0fdc0e09-f8e1-4bb7-a610-5aa6233d59f4

