### PR TITLE
fix network check (for real this time)

### DIFF
--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -205,6 +205,18 @@ const AuthMethodSelector = ({ onSelect, networkStatus }) => {
   const [escapeKeyTimer, setEscapeKeyTimer] = useState(null);
   const router = useRouter();
 
+  const hasStoredCredentials = typeof window !== 'undefined' && (
+    localStorage.getItem("spotifyRefreshToken") || 
+    localStorage.getItem("spotifyAccessToken")
+  );
+
+  useEffect(() => {
+    if (hasStoredCredentials) {
+      const savedAuthType = localStorage.getItem("spotifyAuthType") || "default";
+      onSelect({ type: savedAuthType });
+    }
+  }, [hasStoredCredentials, onSelect]);
+
   useEffect(() => {
     if (showDefaultButton) {
       setTimeout(() => setDefaultButtonVisible(true), 50);

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -6,7 +6,7 @@ import NetworkScreen from "../bluetooth/NetworkScreen";
 import PairingScreen from "../bluetooth/PairingScreen";
 import EnableTetheringScreen from "../bluetooth/EnableTetheringScreen";
 import { NocturneIcon } from "../icons";
-// import { checkNetworkConnectivity } from "../../lib/networkChecker";
+import { checkNetworkConnectivity } from "../../lib/networkChecker";
 
 const ConnectionScreen = () => {
   const [isBluetoothDiscovering, setIsBluetoothDiscovering] = useState(false);
@@ -21,12 +21,10 @@ const ConnectionScreen = () => {
     localStorage.getItem("spotifyAccessToken")
   );
 
-  const checkNetworkConnectivity = async () => {
+  const checkNetwork = async () => {
     try {
-      const response = await fetch("https://api.spotify.com/v1", {
-        method: "OPTIONS",
-      });
-      const isConnected = response.ok;
+      const response = await checkNetworkConnectivity();
+      const isConnected = response.isConnected;
       setIsNetworkConnected(isConnected);
       return isConnected;
     } catch (error) {
@@ -117,7 +115,7 @@ const ConnectionScreen = () => {
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     setDeviceType(isIOS ? "ios" : "other");
 
-    checkNetworkConnectivity();
+    checkNetwork();
 
     const ws = new WebSocket("ws://localhost:5000/ws");
 

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -6,6 +6,7 @@ import NetworkScreen from "../bluetooth/NetworkScreen";
 import PairingScreen from "../bluetooth/PairingScreen";
 import EnableTetheringScreen from "../bluetooth/EnableTetheringScreen";
 import { NocturneIcon } from "../icons";
+// import { checkNetworkConnectivity } from "../../lib/networkChecker";
 
 const ConnectionScreen = () => {
   const [isBluetoothDiscovering, setIsBluetoothDiscovering] = useState(false);

--- a/src/lib/networkChecker.js
+++ b/src/lib/networkChecker.js
@@ -24,15 +24,23 @@ export async function checkNetworkConnectivity() {
       throw new NetworkError(`HTTP error! status: ${response.status}`);
     }
 
-    return {
-      isConnected: true
-    };
+    if (response.ok) {
+      return {
+        isConnected: true
+      };
+    }
   } catch (error) {
     if (error.name === "AbortError") {
-      throw new NetworkError("Network request timed out");
+      return {
+        isConnected: false,
+        error: "Network request timed out"
+      };
     }
     if (error instanceof NetworkError) {
-      throw error;
+      return {
+        isConnected: false,
+        error: error.message
+      };
     }
     throw new NetworkError(
       error.message || "Network connectivity check failed"

--- a/src/lib/networkChecker.js
+++ b/src/lib/networkChecker.js
@@ -5,22 +5,15 @@ export class NetworkError extends Error {
   }
 }
 
-export async function checkNetworkConnectivity(accessToken) {
-  if (!accessToken) {
-    throw new NetworkError("No access token available");
-  }
-
+export async function checkNetworkConnectivity() {
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const timeoutId = setTimeout(() => controller.abort(), 50000);
 
     const response = await fetch(
-      "https://api.spotify.com/v1/me/player/devices",
+      "https://api.spotify.com/v1/",
       {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
+        method: "OPTIONS",
         signal: controller.signal,
       }
     );
@@ -28,18 +21,11 @@ export async function checkNetworkConnectivity(accessToken) {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
-        throw new NetworkError("Authorization error");
-      }
       throw new NetworkError(`HTTP error! status: ${response.status}`);
     }
 
     return {
-      isConnected: true,
-      hasDevices: async () => {
-        const data = await response.json();
-        return data.devices && data.devices.length > 0;
-      },
+      isConnected: true
     };
   } catch (error) {
     if (error.name === "AbortError") {
@@ -55,7 +41,6 @@ export async function checkNetworkConnectivity(accessToken) {
 }
 
 export async function waitForNetwork(
-  accessToken,
   maxAttempts = 3,
   delayMs = 2000
 ) {
@@ -63,7 +48,7 @@ export async function waitForNetwork(
 
   while (attempts < maxAttempts) {
     try {
-      const status = await checkNetworkConnectivity(accessToken);
+      const status = await checkNetworkConnectivity();
       return status;
     } catch (error) {
       attempts++;
@@ -75,12 +60,12 @@ export async function waitForNetwork(
   }
 }
 
-export function startNetworkMonitoring(accessToken, onStatusChange) {
+export function startNetworkMonitoring(onStatusChange) {
   let isOnline = true;
 
   const checkConnection = async () => {
     try {
-      await checkNetworkConnectivity(accessToken);
+      await checkNetworkConnectivity();
       if (!isOnline) {
         isOnline = true;
         onStatusChange?.(true);

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -153,12 +153,7 @@ export default function App({ Component, pageProps }) {
       }
       const intervalId = setInterval(async () => {
         try {
-          const savedAccessToken = localStorage.getItem("spotifyAccessToken");
-          if (savedAccessToken) {
-            await checkNetworkConnectivity(savedAccessToken);
-          } else {
-            await fetch("https://api.spotify.com/v1", { method: "OPTIONS" });
-          }
+          await checkNetworkConnectivity();
           clearInterval(intervalId);
           setNetworkStatus({ isConnected: true });
         } catch (error) {
@@ -207,9 +202,7 @@ export default function App({ Component, pageProps }) {
       if (typeof window === "undefined") return;
 
       try {
-        await checkNetworkConnectivity(
-          localStorage.getItem("spotifyAccessToken")
-        );
+        await checkNetworkConnectivity();
       } catch (error) {
         setAuthState({
           authSelectionMade: false,
@@ -305,7 +298,7 @@ export default function App({ Component, pageProps }) {
         async (isConnected) => {
           try {
             if (isConnected) {
-              const status = await checkNetworkConnectivity(accessToken);
+              const status = await checkNetworkConnectivity();
               setNetworkStatus({ isConnected: true });
             } else {
               setNetworkStatus({ isConnected: false });

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -562,14 +562,17 @@ export default function App({ Component, pageProps }) {
         fontOpticalSizing: "auto",
       }}
     >
-      {!authState.authSelectionMade &&
-      !router.pathname.includes("phone-auth") &&
-      !window.location.search.includes("code") ? (
+      {(!networkStatus?.isConnected && !router.pathname.includes("phone-auth")) ||
+      (!authState.authSelectionMade &&
+        !router.pathname.includes("phone-auth") &&
+        !window.location.search.includes("code") &&
+        !localStorage.getItem("spotifyRefreshToken") &&
+        !localStorage.getItem("spotifyAccessToken")) ? (
         <AuthSelection
           onSelect={hookHandleAuthSelection}
           networkStatus={networkStatus}
         />
-      ) : (
+      ) : networkStatus?.isConnected ? (
         <>
           <div
             style={{
@@ -652,6 +655,11 @@ export default function App({ Component, pageProps }) {
             activeButton={pressedButton}
           />
         </>
+      ) : (
+        <AuthSelection
+          onSelect={hookHandleAuthSelection}
+          networkStatus={networkStatus}
+        />
       )}
     </main>
   );


### PR DESCRIPTION
changes:
- uses OPTIONS instead of GET request on devices endpoint, fixes network check failing if access token is expired
- bluetooth networking works now, instead of it failing the network checks all the time
- loads straight into nocturne ui if network check passes and stored credentials are available

issues:
- not that I know of