### PR TITLE
fixes and features for bluetooth, status bar, etc.

### DIFF
--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -54,6 +54,7 @@ const ConnectionScreen = () => {
     const lastDeviceAddress = localStorage.getItem('connectedBluetoothAddress');
     if (failedReconnectAttemptsRef.current >= 10) {
       if (reconnectInterval) {
+        console.log("Stopping automatic reconnection attempts - reached maximum failure attempts");
         clearInterval(reconnectInterval);
         reconnectInterval = null;
       }
@@ -143,6 +144,7 @@ const ConnectionScreen = () => {
       const intervalId = setInterval(async () => {
         try {
           if (failedNetworkAttempts >= 10) {
+            console.log("Stopping automatic network enabling attempts - reached maximum failure attempts");
             clearInterval(intervalId);
             return;
           }

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -226,7 +226,9 @@ const ConnectionScreen = () => {
 
     const startNetworkCheck = async () => {
       const lastDeviceAddress = localStorage.getItem('connectedBluetoothAddress');
-      if (lastDeviceAddress) {
+      if (!lastDeviceAddress) {
+        enableBluetoothDiscovery();
+      } else {
         reconnectionAttemptedRef.current = false;
         failedReconnectAttemptsRef.current = 0;
         
@@ -260,8 +262,6 @@ const ConnectionScreen = () => {
           setShowNoNetwork(false);
           setShowTethering(true);
         }
-      } else {
-        enableBluetoothDiscovery();
       }
 
       initialCheckTimeoutRef.current = setTimeout(() => {

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -323,6 +323,17 @@ const ConnectionScreen = () => {
         setShowNoNetwork(false);
         setShowTethering(true);
         enableBluetoothNetwork(address);
+      } else if (data.type === "bluetooth/connect") {
+        const { address } = data;
+        localStorage.setItem('connectedBluetoothAddress', address);
+        setShowNoNetwork(false);
+        setShowTethering(true);
+        reconnectionAttemptedRef.current = true;
+        if (reconnectInterval) {
+          clearInterval(reconnectInterval);
+          reconnectInterval = null;
+        }
+        enableBluetoothNetwork(address);
       } else if (data.type === "bluetooth/network/disconnect") {
         const lastDeviceAddress = localStorage.getItem('connectedBluetoothAddress');
         if (lastDeviceAddress) {

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -260,6 +260,8 @@ const ConnectionScreen = () => {
           setShowNoNetwork(false);
           setShowTethering(true);
         }
+      } else {
+        enableBluetoothDiscovery();
       }
 
       initialCheckTimeoutRef.current = setTimeout(() => {
@@ -269,10 +271,6 @@ const ConnectionScreen = () => {
       }, 5000);
 
       const isConnected = await checkNetwork();
-      
-      if (!isConnected && !lastDeviceAddress) {
-        enableBluetoothDiscovery();
-      }
       
       checkInterval = setInterval(async () => {
         if (!mounted) return;

--- a/src/components/auth/AuthSelection.jsx
+++ b/src/components/auth/AuthSelection.jsx
@@ -319,6 +319,7 @@ const ConnectionScreen = () => {
         setPairingKey(pairingKey);
       } else if (data.type === "bluetooth/paired") {
         const { address } = data.payload.device;
+        localStorage.setItem('connectedBluetoothAddress', address);
         setShowNoNetwork(false);
         setShowTethering(true);
         enableBluetoothNetwork(address);

--- a/src/components/bluetooth/BluetoothDevices.jsx
+++ b/src/components/bluetooth/BluetoothDevices.jsx
@@ -88,11 +88,24 @@ const BluetoothDevices = () => {
     }
   };
 
-  const handleForget = () => {
+  const handleForget = async () => {
     if (selectedDevice) {
-      setDevices(devices.filter((device) => device.address !== selectedDevice));
-      setShowForgetDialog(false);
-      setSelectedDevice(null);
+      try {
+        const response = await fetch(`http://localhost:5000/bluetooth/remove/${selectedDevice}`, {
+          method: 'POST'
+        });
+        
+        if (!response.ok) {
+          throw new Error('Failed to remove device');
+        }
+
+        localStorage.removeItem('connectedBluetoothAddress');
+        setDevices(devices.filter((device) => device.address !== selectedDevice));
+        setShowForgetDialog(false);
+        setSelectedDevice(null);
+      } catch (err) {
+        setError(err.message);
+      }
     }
   };
 

--- a/src/components/bluetooth/BluetoothDevices.jsx
+++ b/src/components/bluetooth/BluetoothDevices.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import {
   Dialog,
   DialogPanel,
@@ -8,30 +8,36 @@ import {
 import { inter } from "../../constants/fonts";
 
 const BluetoothDevices = () => {
-  const [devices, setDevices] = useState([
-    {
-      id: "1",
-      name: "iPhone 14 Pro",
-      status: "connected",
-      type: "phone",
-    },
-    {
-      id: "2",
-      name: "Galaxy S23 Ultra With A Really Long Name That Should Truncate",
-      status: "disconnected",
-      type: "phone",
-    },
-    {
-      id: "3",
-      name: "Pixel 8",
-      status: "disconnected",
-      type: "phone",
-    },
-  ]);
+  const [devices, setDevices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [showForgetDialog, setShowForgetDialog] = useState(false);
   const [selectedDevice, setSelectedDevice] = useState(null);
   const longPressTimer = useRef(null);
   const buttonPressInProgress = useRef(false);
+
+  useEffect(() => {
+    const fetchDevices = async () => {
+      try {
+        const response = await fetch('http://localhost:5000/bluetooth/devices');
+        if (!response.ok) {
+          throw new Error('Failed to fetch devices');
+        }
+        const data = await response.json();
+        const mappedDevices = data.map(device => ({
+          ...device,
+          status: device.connected ? "connected" : "disconnected"
+        }));
+        setDevices(mappedDevices);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDevices();
+  }, []);
 
   const handleConnect = (deviceId) => {
     setDevices(

--- a/src/components/common/navigation/Sidebar.jsx
+++ b/src/components/common/navigation/Sidebar.jsx
@@ -11,45 +11,6 @@ import {
 import StatusBar from "./StatusBar";
 
 export default function Sidebar({ activeSection, setActiveSection }) {
-  const [isBluetoothTethered, setIsBluetoothTethered] = useState(false);
-
-  useEffect(() => {
-    const ws = new WebSocket("ws://localhost:5000/ws");
-
-    ws.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      if (data.type === "bluetooth/network") {
-        setIsBluetoothTethered(true);
-      }
-    };
-
-    ws.onerror = () => {
-      setIsBluetoothTethered(false);
-    };
-
-    ws.onclose = () => {
-      setIsBluetoothTethered(false);
-    };
-
-    const checkCurrentConnection = async () => {
-      try {
-        const response = await fetch("http://localhost:5000/bluetooth/status");
-        if (response.ok) {
-          const data = await response.json();
-          setIsBluetoothTethered(data.isNetworkEnabled || false);
-        }
-      } catch (error) {
-        setIsBluetoothTethered(false);
-      }
-    };
-
-    checkCurrentConnection();
-
-    return () => {
-      ws.close();
-    };
-  }, []);
-
   const handleSectionClick = (section) => {
     setActiveSection(section);
   };
@@ -80,7 +41,7 @@ export default function Sidebar({ activeSection, setActiveSection }) {
 
   return (
     <div className="space-y-7 pt-12">
-      {isBluetoothTethered && <StatusBar />}
+      <StatusBar />
       <Link href={`/now-playing`}>
         <div className="relative flex items-center">
           <div className="mr-4 flex-shrink-0">

--- a/src/components/common/navigation/StatusBar.jsx
+++ b/src/components/common/navigation/StatusBar.jsx
@@ -74,7 +74,6 @@ const StatusBar = () => {
           } else {
             setIsBluetoothTethered(false);
             setConnectedDeviceAddress(null);
-            localStorage.removeItem('connectedBluetoothAddress');
             failedDeviceChecksRef.current++;
             return false;
           }

--- a/src/components/common/navigation/StatusBar.jsx
+++ b/src/components/common/navigation/StatusBar.jsx
@@ -128,7 +128,6 @@ const StatusBar = () => {
         }
       } else if (data.type === "bluetooth/network/disconnect" || data.type === "bluetooth/disconnect") {
         setIsBluetoothTethered(false);
-        localStorage.removeItem('connectedBluetoothAddress');
         setBatteryPercentage(80);
 
         if (batteryCheckIntervalRef.current) {
@@ -140,7 +139,6 @@ const StatusBar = () => {
 
     ws.onerror = () => {
       setIsBluetoothTethered(false);
-      localStorage.removeItem('connectedBluetoothAddress');
       setBatteryPercentage(80);
       if (batteryCheckIntervalRef.current) {
         clearInterval(batteryCheckIntervalRef.current);
@@ -150,7 +148,6 @@ const StatusBar = () => {
 
     ws.onclose = () => {
       setIsBluetoothTethered(false);
-      localStorage.removeItem('connectedBluetoothAddress');
       setBatteryPercentage(80);
       if (batteryCheckIntervalRef.current) {
         clearInterval(batteryCheckIntervalRef.current);

--- a/src/components/icons/BatteryIcon.jsx
+++ b/src/components/icons/BatteryIcon.jsx
@@ -25,7 +25,7 @@ const BatteryIcon = ({ percentage = 100, className }) => {
               fontSize="10"
               fontWeight="600"
               fill="black"
-              fontFamily="system-ui, -apple-system, sans-serif"
+              fontFamily="var(--font-inter)"
             >
               {percentage}
             </text>
@@ -35,14 +35,14 @@ const BatteryIcon = ({ percentage = 100, className }) => {
           <rect width="22" height="13" fill="black" />
           {percentage > 0 && (
             <text
-              x="11"
+              x="11" 
               y="6.5"
               textAnchor="middle"
               alignmentBaseline="central"
               fontSize="10"
               fontWeight="600"
               fill="white"
-              fontFamily="system-ui, -apple-system, sans-serif"
+              fontFamily="var(--font-inter)"
             >
               {percentage}
             </text>

--- a/src/components/icons/BatteryIcon.jsx
+++ b/src/components/icons/BatteryIcon.jsx
@@ -19,7 +19,7 @@ const BatteryIcon = ({ percentage = 100, className }) => {
           {percentage > 0 && (
             <text
               x="11"
-              y="6.5"
+              y="7"
               textAnchor="middle"
               alignmentBaseline="central"
               fontSize="10"
@@ -36,7 +36,7 @@ const BatteryIcon = ({ percentage = 100, className }) => {
           {percentage > 0 && (
             <text
               x="11"
-              y="6.5"
+              y="7"
               textAnchor="middle"
               alignmentBaseline="central"
               fontSize="10"

--- a/src/components/icons/BatteryIcon.jsx
+++ b/src/components/icons/BatteryIcon.jsx
@@ -19,7 +19,7 @@ const BatteryIcon = ({ percentage = 100, className }) => {
           {percentage > 0 && (
             <text
               x="11"
-              y="7"
+              y="6.5"
               textAnchor="middle"
               alignmentBaseline="central"
               fontSize="10"
@@ -36,7 +36,7 @@ const BatteryIcon = ({ percentage = 100, className }) => {
           {percentage > 0 && (
             <text
               x="11"
-              y="7"
+              y="6.5"
               textAnchor="middle"
               alignmentBaseline="central"
               fontSize="10"

--- a/src/components/player/ProgressBar.jsx
+++ b/src/components/player/ProgressBar.jsx
@@ -77,9 +77,6 @@ const ProgressBar = ({
     setIsScrubbing(true);
     onScrubbingChange(true);
     wasPlayingRef.current = isPlaying;
-    if (isPlaying) {
-      onPlayPause();
-    }
   };
 
   useEffect(() => {
@@ -107,35 +104,29 @@ const ProgressBar = ({
         event.preventDefault();
 
         setInterpolatedProgress(scrubbingProgress);
-
         setIsScrubbing(false);
         onScrubbingChange(false);
 
         if (scrubbingProgress !== null) {
           const seekMs = Math.floor((scrubbingProgress / 100) * durationMs);
           onSeek(seekMs);
-          if (wasPlayingRef.current) {
-            setTimeout(() => {
-              onPlayPause();
-            }, 100);
-          }
         }
 
         setScrubbingProgress(null);
       } else if (event.key === "Escape" && isScrubbing) {
         event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
         setIsScrubbing(false);
         onScrubbingChange(false);
         setScrubbingProgress(null);
         setInterpolatedProgress(progress);
-        if (wasPlayingRef.current) {
-          onPlayPause();
-        }
+        return false;
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
   }, [
     isScrubbing,
     scrubbingProgress,

--- a/src/components/player/ProgressBar.jsx
+++ b/src/components/player/ProgressBar.jsx
@@ -102,6 +102,8 @@ const ProgressBar = ({
     const handleKeyDown = (event) => {
       if (event.key === "Enter" && isScrubbing) {
         event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
 
         setInterpolatedProgress(scrubbingProgress);
         setIsScrubbing(false);
@@ -113,6 +115,7 @@ const ProgressBar = ({
         }
 
         setScrubbingProgress(null);
+        return false;
       } else if (event.key === "Escape" && isScrubbing) {
         event.preventDefault();
         event.stopPropagation();

--- a/src/components/player/ProgressBar.jsx
+++ b/src/components/player/ProgressBar.jsx
@@ -83,26 +83,22 @@ const ProgressBar = ({
   };
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+    if (!isScrubbing) return;
 
     const handleWheel = (event) => {
-      if (isScrubbing) {
-        event.preventDefault();
-        event.stopPropagation();
-        const delta = event.deltaX;
-        const step = 0.5;
+      event.preventDefault();
+      event.stopPropagation();
+      const delta = event.deltaX;
+      const step = 0.5;
 
-        setScrubbingProgress((prev) => {
-          const nextValue =
-            (prev ?? interpolatedProgress) + (delta > 0 ? step : -step);
-          return Math.max(0, Math.min(100, nextValue));
-        });
-      }
+      setScrubbingProgress((prev) => {
+        const nextValue = (prev ?? interpolatedProgress) + (delta > 0 ? step : -step);
+        return Math.max(0, Math.min(100, nextValue));
+      });
     };
 
-    container.addEventListener("wheel", handleWheel, { passive: false });
-    return () => container.removeEventListener("wheel", handleWheel);
+    window.addEventListener("wheel", handleWheel, { passive: false });
+    return () => window.removeEventListener("wheel", handleWheel);
   }, [isScrubbing, interpolatedProgress]);
 
   useEffect(() => {

--- a/src/constants/errorCodes.js
+++ b/src/constants/errorCodes.js
@@ -38,6 +38,7 @@ export const ErrorCodes = {
   FETCH_PLAYLIST_TRACKS_ERROR: "E037",
   REGISTER_DEVICE_ERROR: "E038",
   CERT_COMMON_NAME_ERROR: "E039",
+  NETWORK_ERROR: "E040",
 };
 
 export default ErrorCodes;


### PR DESCRIPTION
changes: 
- fix auto login and stop refreshing page once session restored
- add e40 for network errors 
- hide network errors when loading into UI, and return to no network/enable tethering screen if connection lost 
- status bar appears and disappears according to if device is connected/disconnected, and also shows correct battery percentage
- saves previously connected Bluetooth address and reconnects on boot
- get timezone from nocturne API and use that to set correct time on status bar 
- add connect/disconnect/forget functionality to Bluetooth settings menu 
- start Bluetooth discovery if no address saved and no network 
- battery icon uses correct font rather than system font

issues:
- flashes no network screen on startup (sometimes I think) 
- network bars still do not work, but those require more nocturned changes 
- nitpick but battery info starts at 80 then updates to correct value a little later 

![image](https://github.com/user-attachments/assets/56ea7a47-b31a-4104-a456-aac65503f371)