### PR TITLE
settings changes, and fix scroll position

### DIFF
--- a/src/components/common/navigation/HorizontalScroll.jsx
+++ b/src/components/common/navigation/HorizontalScroll.jsx
@@ -83,6 +83,10 @@ export default function HorizontalScroll({
       const scrollableItems = Array.from(containerRef.current.children);
       setItems(scrollableItems);
       hasScrolledToPlayingRef.current = false;
+      containerRef.current.scrollTo({
+        left: 0,
+        behavior: "smooth",
+      });
     }
   }, [activeSection]);
 

--- a/src/components/common/navigation/TrackListNavigation.jsx
+++ b/src/components/common/navigation/TrackListNavigation.jsx
@@ -25,6 +25,10 @@ const TrackListNavigation = ({
         )
       );
       setItems(trackItems);
+      containerRef.current.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
     };
 
     updateSelectableItems();

--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -245,7 +245,7 @@ const fetchSpotifyProfile = async (accessToken) => {
   }
 };
 
-export default function Settings({ accessToken, onOpenDonationModal }) {
+export default function Settings({ accessToken, onOpenDonationModal, setActiveSection }) {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState("main");
   const [activeSubpage, setActiveSubpage] = useState(null);
@@ -591,6 +591,24 @@ export default function Settings({ accessToken, onOpenDonationModal }) {
         return null;
     }
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape" && !isAnimating) {
+        if (currentPage === "main") {
+          setActiveSection("recents");
+          router.push("/");
+        } else {
+          navigateBack();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isAnimating, navigateBack, currentPage, router, setActiveSection]);
 
   return (
     <div className="h-full overflow-y-auto settings-scroll-container">

--- a/src/hooks/useKeyboardHandlers.js
+++ b/src/hooks/useKeyboardHandlers.js
@@ -11,6 +11,7 @@ export function useKeyboardHandlers({
   setBrightness,
   router,
   setActiveSection,
+  activeSection,
   handleError,
   accessToken,
   refreshToken,
@@ -55,6 +56,9 @@ export function useKeyboardHandlers({
         if (drawerOpen) {
           setDrawerOpen(false);
         } else {
+          if (router.pathname === "/" && activeSection === "settings") {
+            return;
+          }
           const result = handleBack();
 
           if (result.pathname === "/" && result.section) {
@@ -303,6 +307,7 @@ export function useKeyboardHandlers({
     refreshAccessToken,
     handleError,
     setActiveSection,
+    activeSection,
     handleBack,
     updateSectionHistory,
     showBrightnessOverlay,

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -135,6 +135,7 @@ export default function App({ Component, pageProps }) {
     setBrightness,
     router,
     setActiveSection,
+    activeSection,
     handleError,
     accessToken,
     refreshToken,
@@ -144,6 +145,7 @@ export default function App({ Component, pageProps }) {
     fetchCurrentPlayback,
     setPressedButton,
     setShowMappingOverlay,
+    showTutorial,
   });
 
   useEffect(() => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -578,6 +578,7 @@ export default function Home({
                 <Settings
                   accessToken={accessToken}
                   onOpenDonationModal={() => setShowDonationModal(true)}
+                  setActiveSection={setActiveSection}
                 />
               </div>
             )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,6 +22,10 @@ body {
   display: none; /* For Chrome, Safari, and Edge */
 }
 
+.settings-scroll-container {
+  overflow-x: hidden;
+}
+
 .fade-out {
   opacity: 0;
 }


### PR DESCRIPTION
fixes: 
- disabled horizontal scroll on settings pages
- esc on settings subpages goes back 1 page, esc on settings main page goes to recent 
- scroll position resets when switching tabs, previously didn't reset and would put you at same spot in a different tab

issues:
- settings submenu has some weird outline thing (see image)
![image](https://github.com/user-attachments/assets/52abaa66-7371-47d8-95f6-6800220d293f)
