### PR TITLE
Prevent incessant rerenders while playing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,6 @@ import ButtonMappingOverlay from "./components/common/overlays/ButtonMappingOver
 import NetworkBanner from "./components/common/overlays/NetworkBanner";
 import { useNetwork } from "./hooks/useNetwork";
 import { useGradientState } from "./hooks/useGradientState";
-import { PlaybackProgressContext } from "./hooks/usePlaybackProgress";
 import { DeviceSwitcherContext } from "./hooks/useSpotifyPlayerControls";
 import { useBluetooth, useSystemUpdate } from "./hooks/useNocturned";
 import { useSpotifyData } from "./hooks/useSpotifyData";
@@ -26,12 +25,12 @@ import PairingScreen from "./components/auth/PairingScreen";
 
 export const NetworkContext = React.createContext({
   selectedNetwork: null,
-  setSelectedNetwork: () => {},
+  setSelectedNetwork: () => { },
 });
 
 export const ConnectorContext = React.createContext({
   showConnectorModal: false,
-  setShowConnectorModal: () => {},
+  setShowConnectorModal: () => { },
 });
 
 function useGlobalButtonMapping({
@@ -288,7 +287,6 @@ function App() {
     playerIsLoading,
     playerError,
     refreshPlaybackState,
-    playbackProgress,
     playerControls,
     recentAlbums,
     userPlaylists,
@@ -572,97 +570,95 @@ function App() {
   return (
     <ConnectorProvider>
       <SettingsProvider>
-        <PlaybackProgressContext.Provider value={playbackProgress}>
-          <DeviceSwitcherContext.Provider value={deviceSwitcherContextValue}>
-            <NetworkContext.Provider value={networkContextValue}>
-              <ConnectorContext.Provider value={connectorContextValue}>
-                <Router>
-                  <FontLoader />
-                  <main
-                    className="overflow-hidden relative min-h-screen rounded-2xl"
+        <DeviceSwitcherContext.Provider value={deviceSwitcherContextValue}>
+          <NetworkContext.Provider value={networkContextValue}>
+            <ConnectorContext.Provider value={connectorContextValue}>
+              <Router>
+                <FontLoader />
+                <main
+                  className="overflow-hidden relative min-h-screen rounded-2xl"
+                  style={{
+                    fontFamily: `var(--font-inter), var(--font-noto-sans-sc), var(--font-noto-sans-tc), var(--font-noto-serif-jp), var(--font-noto-sans-kr), var(--font-noto-naskh-ar), var(--font-noto-sans-bn), var(--font-noto-sans-dv), var(--font-noto-sans-he), var(--font-noto-sans-ta), var(--font-noto-sans-th), var(--font-noto-sans-gk), system-ui, sans-serif`,
+                    fontOpticalSizing: "auto",
+                  }}
+                >
+                  <div
                     style={{
-                      fontFamily: `var(--font-inter), var(--font-noto-sans-sc), var(--font-noto-sans-tc), var(--font-noto-serif-jp), var(--font-noto-sans-kr), var(--font-noto-naskh-ar), var(--font-noto-sans-bn), var(--font-noto-sans-dv), var(--font-noto-sans-he), var(--font-noto-sans-ta), var(--font-noto-sans-th), var(--font-noto-sans-gk), system-ui, sans-serif`,
-                      fontOpticalSizing: "auto",
+                      backgroundImage: generateMeshGradient([
+                        currentColor1,
+                        currentColor2,
+                        currentColor3,
+                        currentColor4,
+                      ]),
+                      transition: "background-image 0.5s linear",
                     }}
-                  >
-                    <div
-                      style={{
-                        backgroundImage: generateMeshGradient([
-                          currentColor1,
-                          currentColor2,
-                          currentColor3,
-                          currentColor4,
-                        ]),
-                        transition: "background-image 0.5s linear",
-                      }}
-                      className="absolute inset-0 bg-black"
-                    />
+                    className="absolute inset-0 bg-black"
+                  />
 
-                    <div className="relative z-10">
-                      {content}
-                      {!isFlashing && !showTetheringScreen && (
-                        <>
-                          {pairingRequest ? (
-                            <PairingScreen
-                              pin={pairingRequest.pairingKey}
-                              isConnecting={isConnecting}
-                              onAccept={acceptPairing}
-                              onReject={denyPairing}
-                            />
-                          ) : !isConnected && lastConnectedDevice ? (
-                            <NetworkScreen
-                              deviceName={lastConnectedDevice.name}
-                              isConnectionLost={true}
-                              isTetheringRequired={isTetheringRequired}
-                              onRetryDismiss={stopRetrying}
-                            />
-                          ) : showNoNetwork ? (
-                            <NetworkScreen 
-                              isConnectionLost={true}
-                              isTetheringRequired={isTetheringRequired}
-                            />
-                          ) : null}
-                        </>
-                      )}
-                      <NetworkBanner 
-                        visible={showNetworkBanner} 
-                        onClose={dismissNetworkBanner}
+                  <div className="relative z-10">
+                    {content}
+                    {!isFlashing && !showTetheringScreen && (
+                      <>
+                        {pairingRequest ? (
+                          <PairingScreen
+                            pin={pairingRequest.pairingKey}
+                            isConnecting={isConnecting}
+                            onAccept={acceptPairing}
+                            onReject={denyPairing}
+                          />
+                        ) : !isConnected && lastConnectedDevice ? (
+                          <NetworkScreen
+                            deviceName={lastConnectedDevice.name}
+                            isConnectionLost={true}
+                            isTetheringRequired={isTetheringRequired}
+                            onRetryDismiss={stopRetrying}
+                          />
+                        ) : showNoNetwork ? (
+                          <NetworkScreen
+                            isConnectionLost={true}
+                            isTetheringRequired={isTetheringRequired}
+                          />
+                        ) : null}
+                      </>
+                    )}
+                    <NetworkBanner
+                      visible={showNetworkBanner}
+                      onClose={dismissNetworkBanner}
+                    />
+                    <SystemUpdateModal
+                      show={isFlashing}
+                      status={updateStatus}
+                      progress={progress}
+                      isError={isError}
+                      errorMessage={errorMessage}
+                    />
+                    <DeviceSwitcherModal
+                      isOpen={isDeviceSwitcherOpen}
+                      onClose={handleCloseDeviceSwitcher}
+                      accessToken={accessToken}
+                    />
+                    <NetworkPasswordModal
+                      network={selectedNetwork}
+                      onClose={handleNetworkClose}
+                      onConnect={handleNetworkClose}
+                    />
+                    {showConnectorModal && (
+                      <ConnectorQRModal
+                        onClose={() => setShowConnectorModal(false)}
                       />
-                      <SystemUpdateModal
-                        show={isFlashing}
-                        status={updateStatus}
-                        progress={progress}
-                        isError={isError}
-                        errorMessage={errorMessage}
+                    )}
+                    {!showTutorial && showGlobalMappingOverlay && (
+                      <ButtonMappingOverlay
+                        show={showGlobalMappingOverlay}
+                        activeButton={globalActiveButton}
                       />
-                      <DeviceSwitcherModal
-                        isOpen={isDeviceSwitcherOpen}
-                        onClose={handleCloseDeviceSwitcher}
-                        accessToken={accessToken}
-                      />
-                      <NetworkPasswordModal
-                        network={selectedNetwork}
-                        onClose={handleNetworkClose}
-                        onConnect={handleNetworkClose}
-                      />
-                      {showConnectorModal && (
-                        <ConnectorQRModal
-                          onClose={() => setShowConnectorModal(false)}
-                        />
-                      )}
-                      {!showTutorial && showGlobalMappingOverlay && (
-                        <ButtonMappingOverlay
-                          show={showGlobalMappingOverlay}
-                          activeButton={globalActiveButton}
-                        />
-                      )}
-                    </div>
-                  </main>
-                </Router>
-              </ConnectorContext.Provider>
-            </NetworkContext.Provider>
-          </DeviceSwitcherContext.Provider>
-        </PlaybackProgressContext.Provider>
+                    )}
+                  </div>
+                </main>
+              </Router>
+            </ConnectorContext.Provider>
+          </NetworkContext.Provider>
+        </DeviceSwitcherContext.Provider>
       </SettingsProvider>
     </ConnectorProvider>
   );

--- a/src/components/player/NowPlaying.jsx
+++ b/src/components/player/NowPlaying.jsx
@@ -498,6 +498,7 @@ const NowPlaying = ({
           onSeek={handleSeek}
           onPlayPause={handlePlayPause}
           onScrubbingChange={handleScrubbingChange}
+          updateProgress={updateProgress}
         />
       </div>
 

--- a/src/components/player/ProgressBar.jsx
+++ b/src/components/player/ProgressBar.jsx
@@ -1,20 +1,14 @@
 import React, { useState, useEffect, useRef } from "react";
-import { usePlaybackProgressConsumer } from "../../hooks/usePlaybackProgress";
 
 const ProgressBar = ({
-  progress: externalProgress,
-  isPlaying: externalIsPlaying,
-  durationMs: externalDurationMs,
+  progress,
+  isPlaying,
+  durationMs,
   onSeek,
   onPlayPause,
   onScrubbingChange,
+  updateProgress,
 }) => {
-  const progressContext = usePlaybackProgressConsumer();
-
-  const progress = externalProgress ?? progressContext.progressPercentage;
-  const isPlaying = externalIsPlaying ?? progressContext.isPlaying;
-  const durationMs = externalDurationMs ?? progressContext.duration;
-
   const [isScrubbing, setIsScrubbing] = useState(false);
   const [scrubbingProgress, setScrubbingProgress] = useState(null);
   const wasPlayingRef = useRef(false);
@@ -59,9 +53,7 @@ const ProgressBar = ({
         if (scrubbingProgress !== null) {
           const seekMs = Math.floor((scrubbingProgress / 100) * durationMs);
           onSeek(seekMs);
-          if (progressContext.updateProgress) {
-            progressContext.updateProgress(seekMs);
-          }
+          updateProgress?.(seekMs);
         }
 
         setScrubbingProgress(null);
@@ -87,7 +79,7 @@ const ProgressBar = ({
     onSeek,
     onPlayPause,
     onScrubbingChange,
-    progressContext,
+    updateProgress,
   ]);
 
   const finalProgress = scrubbingProgress ?? progress;

--- a/src/hooks/usePlaybackProgress.js
+++ b/src/hooks/usePlaybackProgress.js
@@ -1,17 +1,5 @@
-import { useState, useEffect, useRef, useCallback, createContext, useContext } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSpotifyPlayerState } from './useSpotifyPlayerState';
-
-export const PlaybackProgressContext = createContext(null);
-
-export const usePlaybackProgressConsumer = () => {
-  const context = useContext(PlaybackProgressContext);
-
-  if (!context) {
-    throw new Error('usePlaybackProgressConsumer must be used within a PlaybackProgressContext.Provider');
-  }
-
-  return context;
-};
 
 const sharedState = {
   refreshTimeoutId: null,

--- a/src/hooks/useSpotifyData.js
+++ b/src/hooks/useSpotifyData.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "./useAuth";
 import { useSpotifyPlayerState } from "./useSpotifyPlayerState";
-import { usePlaybackProgress } from "./usePlaybackProgress";
 import { useSpotifyPlayerControls } from "./useSpotifyPlayerControls";
 import { networkAwareRequest } from "../utils/networkAwareRequest";
 

--- a/src/hooks/useSpotifyData.js
+++ b/src/hooks/useSpotifyData.js
@@ -58,7 +58,6 @@ export function useSpotifyData(activeSection) {
     refreshPlaybackState,
   } = useSpotifyPlayerState(effectiveToken);
 
-  const playbackProgress = usePlaybackProgress(effectiveToken);
   const playerControls = useSpotifyPlayerControls(effectiveToken);
 
   const initializeWithFreshToken = useCallback(async () => {
@@ -732,7 +731,6 @@ export function useSpotifyData(activeSection) {
     playerIsLoading,
     playerError,
     refreshPlaybackState,
-    playbackProgress,
     playerControls,
     recentAlbums,
     userPlaylists,


### PR DESCRIPTION
This PR removes the top level `PlaybackProgressContext` and unsubscribes `useSpotifyData` from `usePlaybackProgress`, as both things were causing the whole App component to rerender many times per second while music was playing.

The Context provided no value, since there was a circular dependency between it and the `usePlaybackProgress` hook.

Components that need playback information (e.g. `NowPlaying`) should explicitely suscribe to the progress hook.

PS: Best to look at the PR diff with whitespaces changes OFF

Before:
![Screen Recording 2025-04-23 at 19 02 36](https://github.com/user-attachments/assets/2d01d41c-858d-4515-b4e2-2cfaf987535c)

After:
![Screen Recording 2025-04-23 at 19 03 39](https://github.com/user-attachments/assets/f10d35aa-5a2c-4355-ada4-8f9219c4d0e0)


