### PR TITLE
Prevent global rerender while gradient is changing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import ConnectorQRModal from "./components/common/modals/ConnectorQRModal";
 import SystemUpdateModal from "./components/common/modals/SystemUpdateModal";
 import ButtonMappingOverlay from "./components/common/overlays/ButtonMappingOverlay";
 import NetworkBanner from "./components/common/overlays/NetworkBanner";
+import GradientBackground from "./components/common/GradientBackground";
 import { useNetwork } from "./hooks/useNetwork";
 import { useGradientState } from "./hooks/useGradientState";
 import { DeviceSwitcherContext } from "./hooks/useSpotifyPlayerControls";
@@ -320,14 +321,7 @@ function App() {
   const { updateStatus, progress, isUpdating, isError, errorMessage } =
     useSystemUpdate();
 
-  const {
-    currentColor1,
-    currentColor2,
-    currentColor3,
-    currentColor4,
-    generateMeshGradient,
-    updateGradientColors,
-  } = useGradientState(activeSection);
+  const [gradientState, updateGradientColors] = useGradientState(activeSection);
 
   const {
     showMappingOverlay: showGlobalMappingOverlay,
@@ -589,18 +583,7 @@ function App() {
                     fontOpticalSizing: "auto",
                   }}
                 >
-                  <div
-                    style={{
-                      backgroundImage: generateMeshGradient([
-                        currentColor1,
-                        currentColor2,
-                        currentColor3,
-                        currentColor4,
-                      ]),
-                      transition: "background-image 0.5s linear",
-                    }}
-                    className="absolute inset-0 bg-black"
-                  />
+                  <GradientBackground gradientState={gradientState} />
 
                   <div className="relative z-10">
                     {content}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -583,7 +583,7 @@ function App() {
                     fontOpticalSizing: "auto",
                   }}
                 >
-                  <GradientBackground gradientState={gradientState} />
+                  <GradientBackground gradientState={gradientState} className="bg-black" />
 
                   <div className="relative z-10">
                     {content}

--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useGradientState } from "../../hooks/useGradientState";
 import { useAuth } from "../../hooks/useAuth";
 import NocturneIcon from "../common/icons/NocturneIcon";
+import GradientBackground from "./components/common/GradientBackground";
 import QRCodeDisplay from "./QRCodeDisplay";
 import { checkNetworkConnectivity } from "../../utils/networkChecker";
 
@@ -16,14 +17,7 @@ const AuthScreen = ({ onAuthSuccess }) => {
   const { authData, isLoading, initAuth, pollAuthStatus, isAuthenticated } =
     useAuth();
 
-  const {
-    currentColor1,
-    currentColor2,
-    currentColor3,
-    currentColor4,
-    generateMeshGradient,
-    updateGradientColors,
-  } = useGradientState();
+  const [gradientState, updateGradientColors] = useGradientState();
 
   useEffect(() => {
     const checkNetwork = async () => {
@@ -134,18 +128,7 @@ const AuthScreen = ({ onAuthSuccess }) => {
 
   return (
     <div className="h-screen flex items-center justify-center overflow-hidden fixed inset-0 rounded-2xl">
-      <div
-        style={{
-          backgroundImage: generateMeshGradient([
-            currentColor1,
-            currentColor2,
-            currentColor3,
-            currentColor4,
-          ]),
-          transition: "background-image 0.5s linear",
-        }}
-        className="absolute inset-0"
-      />
+      <GradientBackground gradientState={gradientState} />
 
       <div className="relative z-10 w-full max-w-6xl px-6 grid grid-cols-2 gap-16 items-center">
         <div className="flex flex-col items-start space-y-8 ml-12">

--- a/src/components/auth/AuthScreen.jsx
+++ b/src/components/auth/AuthScreen.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useGradientState } from "../../hooks/useGradientState";
 import { useAuth } from "../../hooks/useAuth";
 import NocturneIcon from "../common/icons/NocturneIcon";
-import GradientBackground from "./components/common/GradientBackground";
+import GradientBackground from "../common/GradientBackground";
 import QRCodeDisplay from "./QRCodeDisplay";
 import { checkNetworkConnectivity } from "../../utils/networkChecker";
 

--- a/src/components/auth/NetworkScreen.jsx
+++ b/src/components/auth/NetworkScreen.jsx
@@ -10,6 +10,7 @@ import {
 } from "../common/icons";
 import WiFiNetworks from "../settings/network/WiFiNetworks";
 import BluetoothDevices from "../settings/network/BluetoothDevices";
+import GradientBackground from "./components/common/GradientBackground";
 
 const NetworkScreen = ({ isConnectionLost = true, onRetryDismiss = null, isTetheringRequired = false }) => {
   const [showMain, setShowMain] = React.useState(true);
@@ -59,14 +60,7 @@ const NetworkScreen = ({ isConnectionLost = true, onRetryDismiss = null, isTethe
 
   const ANIMATION_DURATION = 300;
 
-  const {
-    currentColor1,
-    currentColor2,
-    currentColor3,
-    currentColor4,
-    generateMeshGradient,
-    updateGradientColors,
-  } = useGradientState();
+  const [gradientState, updateGradientColors] = useGradientState();
 
   useEffect(() => {
     updateGradientColors(null, "auth");
@@ -183,18 +177,7 @@ const NetworkScreen = ({ isConnectionLost = true, onRetryDismiss = null, isTethe
   return (
     <div className="h-screen w-full flex items-center justify-center overflow-hidden fixed inset-0 rounded-2xl z-50">
       <div className="absolute inset-0 bg-black"></div>
-      <div
-        style={{
-          backgroundImage: generateMeshGradient([
-            currentColor1,
-            currentColor2,
-            currentColor3,
-            currentColor4,
-          ]),
-          transition: "background-image 0.5s linear",
-        }}
-        className="absolute inset-0"
-      />
+      <GradientBackground gradientState={gradientState} />
 
       <div className="relative z-10 w-full h-full settings-scroll-container overflow-hidden">
         <div

--- a/src/components/auth/NetworkScreen.jsx
+++ b/src/components/auth/NetworkScreen.jsx
@@ -10,7 +10,7 @@ import {
 } from "../common/icons";
 import WiFiNetworks from "../settings/network/WiFiNetworks";
 import BluetoothDevices from "../settings/network/BluetoothDevices";
-import GradientBackground from "./components/common/GradientBackground";
+import GradientBackground from "../common/GradientBackground";
 
 const NetworkScreen = ({ isConnectionLost = true, onRetryDismiss = null, isTetheringRequired = false }) => {
   const [showMain, setShowMain] = React.useState(true);

--- a/src/components/auth/PairingScreen.jsx
+++ b/src/components/auth/PairingScreen.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useGradientState } from "../../hooks/useGradientState";
 import { NocturneIcon } from "../common/icons";
-import GradientBackground from "./components/common/GradientBackground";
+import GradientBackground from "../common/GradientBackground";
 
 const PairingScreen = ({ onAccept, onReject, pin, isConnecting }) => {
   const [gradientState, updateGradientColors] = useGradientState();

--- a/src/components/auth/PairingScreen.jsx
+++ b/src/components/auth/PairingScreen.jsx
@@ -1,16 +1,10 @@
 import { useEffect } from "react";
 import { useGradientState } from "../../hooks/useGradientState";
 import { NocturneIcon } from "../common/icons";
+import GradientBackground from "./components/common/GradientBackground";
 
 const PairingScreen = ({ onAccept, onReject, pin, isConnecting }) => {
-  const {
-    currentColor1,
-    currentColor2,
-    currentColor3,
-    currentColor4,
-    generateMeshGradient,
-    updateGradientColors,
-  } = useGradientState();
+  const [gradientState, updateGradientColors] = useGradientState();
 
   useEffect(() => {
     updateGradientColors(null, "auth");
@@ -19,18 +13,7 @@ const PairingScreen = ({ onAccept, onReject, pin, isConnecting }) => {
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center overflow-hidden">
       <div className="absolute inset-0 bg-black"></div>
-      <div
-        style={{
-          backgroundImage: generateMeshGradient([
-            currentColor1,
-            currentColor2,
-            currentColor3,
-            currentColor4,
-          ]),
-          transition: "background-image 0.5s linear",
-        }}
-        className="absolute inset-0"
-      />
+      <GradientBackground gradientState={gradientState} />
 
       <div className="relative z-10 w-full max-w-6xl px-6 grid grid-cols-2 gap-16 items-center">
         <div className="flex flex-col items-start space-y-8 ml-12">

--- a/src/components/common/GradientBackground.jsx
+++ b/src/components/common/GradientBackground.jsx
@@ -1,11 +1,13 @@
 import { useEffect } from 'react';
 import { useGradientTransition } from '../../hooks/useGradientTransition';
+import classNames from 'classnames';
 
 const GradientBackground = ({
   gradientState = {
     imageURL: null,
     section: null,
   },
+  className = ""
 }) => {
   const {
     currentColor1,
@@ -31,7 +33,7 @@ const GradientBackground = ({
         ]),
         transition: 'background-image 0.5s linear',
       }}
-      className="absolute inset-0"
+      className={classNames("absolute", "inset-0", className)}
     />
   );
 };

--- a/src/components/common/GradientBackground.jsx
+++ b/src/components/common/GradientBackground.jsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useGradientTransition } from '../../hooks/useGradientTransition';
+
+const GradientBackground = ({
+  gradientState = {
+    imageURL: null,
+    section: null,
+  },
+}) => {
+  const {
+    currentColor1,
+    currentColor2,
+    currentColor3,
+    currentColor4,
+    generateMeshGradient,
+    updateGradientColors,
+  } = useGradientTransition(gradientState.section);
+
+  useEffect(() => {
+    updateGradientColors(gradientState.imageURL, gradientState.section);
+  }, [updateGradientColors, gradientState]);
+
+  return (
+    <div
+      style={{
+        backgroundImage: generateMeshGradient([
+          currentColor1,
+          currentColor2,
+          currentColor3,
+          currentColor4,
+        ]),
+        transition: 'background-image 0.5s linear',
+      }}
+      className="absolute inset-0"
+    />
+  );
+};
+
+export default GradientBackground;

--- a/src/components/tutorial/Tutorial.jsx
+++ b/src/components/tutorial/Tutorial.jsx
@@ -262,7 +262,7 @@ const Tutorial = ({ onComplete }) => {
 
   return (
     <div className="fixed inset-0 w-full h-full" ref={tutorialContainerRef}>
-      <GradientBackground gradientState={gradientState} />
+      <GradientBackground gradientState={gradientState} className="rounded-2xl" />
 
       <div className="relative h-full z-10 flex justify-between px-6">
         <div className="flex flex-col items-start w-1/2 -mr-6 ml-12 flex-1 justify-center">

--- a/src/components/tutorial/Tutorial.jsx
+++ b/src/components/tutorial/Tutorial.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import TutorialFrame from "./TutorialFrame";
 import NocturneIcon from "../common/icons/NocturneIcon";
-import GradientBackground from "./components/common/GradientBackground";
+import GradientBackground from "../common/GradientBackground";
 import { useGradientState } from "../../hooks/useGradientState";
 import { useNavigation } from "../../hooks/useNavigation";
 

--- a/src/components/tutorial/Tutorial.jsx
+++ b/src/components/tutorial/Tutorial.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import TutorialFrame from "./TutorialFrame";
 import NocturneIcon from "../common/icons/NocturneIcon";
+import GradientBackground from "./components/common/GradientBackground";
 import { useGradientState } from "../../hooks/useGradientState";
 import { useNavigation } from "../../hooks/useNavigation";
 
@@ -15,14 +16,7 @@ const Tutorial = ({ onComplete }) => {
   const buttonLockRef = useRef(false);
   const lastPressedKey = useRef(null);
 
-  const {
-    currentColor1,
-    currentColor2,
-    currentColor3,
-    currentColor4,
-    generateMeshGradient,
-    updateGradientColors,
-  } = useGradientState();
+  const [gradientState, updateGradientColors] = useGradientState();
 
   useEffect(() => {
     updateGradientColors(null, "auth");
@@ -268,18 +262,7 @@ const Tutorial = ({ onComplete }) => {
 
   return (
     <div className="fixed inset-0 w-full h-full" ref={tutorialContainerRef}>
-      <div
-        style={{
-          backgroundImage: generateMeshGradient([
-            currentColor1,
-            currentColor2,
-            currentColor3,
-            currentColor4,
-          ]),
-          transition: "background-image 0.5s linear",
-        }}
-        className="absolute inset-0 rounded-2xl"
-      />
+      <GradientBackground gradientState={gradientState} />
 
       <div className="relative h-full z-10 flex justify-between px-6">
         <div className="flex flex-col items-start w-1/2 -mr-6 ml-12 flex-1 justify-center">

--- a/src/hooks/useGradientState.js
+++ b/src/hooks/useGradientState.js
@@ -1,14 +1,26 @@
+import { useMemo } from 'react';
+import { useCallback } from 'react';
 import { useState } from 'react';
 
 export function useGradientState(activeSection = null) {
   const [imageURL, setImageURL] = useState(null);
   const [section, setSection] = useState(activeSection);
 
-  const gradientState = { imageURL, section };
-  const setGradientState = (newImageURL = null, newSection = null) => {
-    setImageURL(newImageURL);
-    setSection(newSection);
-  };
+  const gradientState = useMemo(
+    () => ({
+      imageURL,
+      section,
+    }),
+    [imageURL, section],
+  );
+
+  const setGradientState = useCallback(
+    (newImageURL = null, newSection = null) => {
+      setImageURL(newImageURL);
+      setSection(newSection);
+    },
+    [],
+  );
 
   return [gradientState, setGradientState];
 }

--- a/src/hooks/useGradientState.js
+++ b/src/hooks/useGradientState.js
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export function useGradientState(activeSection = null) {
+  const [imageURL, setImageURL] = useState(null);
+  const [section, setSection] = useState(activeSection);
+
+  const gradientState = { imageURL, section };
+  const setGradientState = (newImageURL = null, newSection = null) => {
+    setImageURL(newImageURL);
+    setSection(newSection);
+  };
+
+  return [gradientState, setGradientState];
+}

--- a/src/hooks/useGradientTransition.js
+++ b/src/hooks/useGradientTransition.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { extractColorsFromImage } from "../utils/colorExtractor";
 
-export function useGradientState(activeSection) {
+export function useGradientTransition(activeSection) {
   const [currentColor1, setCurrentColor1] = useState("#191414");
   const [currentColor2, setCurrentColor2] = useState("#191414");
   const [currentColor3, setCurrentColor3] = useState("#191414");

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -23,7 +23,7 @@ export default function Home({
   refreshPlaybackState,
   onOpenContent,
 }) {
-  const { updateGradientColors } = useGradientState();
+  const [, updateGradientColors] = useGradientState();
   const scrollContainerRef = useRef(null);
   const itemWidth = 290;
   const [newAlbumAdded, setNewAlbumAdded] = useState(false);


### PR DESCRIPTION
This PR splits `useGradientState` into two hooks, `useGradientState` and `useGradientTransition`, and creates a new component, `GradientBackground`. The goal is to prevent the whole app tree from rerendering while the background gradient changes.

The first hook's signature is similar to `useState`'s, returning a tuple of `[gradientState, setGradientState]`. The former is passed to `GradientBackground`, and the latter is a drop-in replacement to `updateGradientColors`.

`useGradientTransition` is the previously existing hook, just renamed. This time it is only consumed inside `GradientBackground`.

`GradientBackground` is a leaf component, so the transition is localized there and its rerenders don't affect the rest of the app.

Before:
![Screen Recording 2025-04-24 at 19 46 37](https://github.com/user-attachments/assets/b98b07e0-06cd-4404-bac5-19024b2537f9)

After:
![Screen Recording 2025-04-24 at 19 42 51](https://github.com/user-attachments/assets/f9fd1a32-b9f3-4ee1-a242-6092a21c47f2)

