### PR TITLE
fix: liked songs crash

### DIFF
--- a/src/components/content/ContentView.jsx
+++ b/src/components/content/ContentView.jsx
@@ -259,7 +259,7 @@ const ContentView = ({
             };
 
             if (updateGradientColors) {
-              updateGradientColors(contentData.images[1].url, contentType);
+              updateGradientColors(contentData.images[0].url, contentType);
             }
 
             tracksData = likedSongsData.items.map((item) => item.track);


### PR DESCRIPTION
Fixes a crash when entering the liked songs playlist, caused by trying to access the element 1 of an array of length 1.

https://github.com/usenocturne/nocturne-ui/blob/d6fa4ab92fb8db7411571223ae93a184f1d66d41/src/components/content/ContentView.jsx#L254-L256

https://github.com/usenocturne/nocturne-ui/blob/d6fa4ab92fb8db7411571223ae93a184f1d66d41/src/components/content/ContentView.jsx#L262