### PR TITLE
feat(lyrics): song info, hide on stop, podcast fix

### DIFF
--- a/src/components/player/NowPlaying.jsx
+++ b/src/components/player/NowPlaying.jsx
@@ -695,7 +695,7 @@ export default function NowPlaying({
       <div ref={contentContainerRef}>
         <div className="md:w-1/3 flex flex-row items-center px-12 pt-10">
           <div
-            className={`min-w-[280px] h-[280px] mr-8 ${albumId ? "cursor-pointer" : ""}`}
+            className={`${showLyrics ? "min-w-[220px]" : "min-w-[280px]"} h-[280px] mr-8 ${albumId ? "cursor-pointer" : ""}`}
             onClick={() =>
               albumId &&
               onNavigateToAlbum &&
@@ -709,15 +709,32 @@ export default function NowPlaying({
                   ? "Podcast Cover"
                   : "Album Art"
               }
-              width={280}
-              height={280}
+              width={showLyrics ? 220 : 280}
+              height={showLyrics ? 220 : 280}
               loading="lazy"
               onError={(e) => {
                 e.currentTarget.onerror = null;
                 e.currentTarget.src = "/images/not-playing.webp";
               }}
-              className="w-[280px] h-[280px] object-cover rounded-[12px] drop-shadow-[0_8px_5px_rgba(0,0,0,0.25)]"
+              className={`${showLyrics ? "w-[220px] h-[220px]" : "w-[280px] h-[280px]"} mb-1 object-cover rounded-[12px] drop-shadow-[0_8px_5px_rgba(0,0,0,0.25)]`}
             />
+            {showLyrics && <><ScrollingText
+                  text={trackName}
+                  className="text-[26px] font-[580] text-white tracking-tight"
+                  maxWidth="400px"
+                  pauseDuration={1000}
+                  pixelsPerSecond={40}
+            />
+            <h4
+                className={`text-[22px] font-[560] text-white/60 truncate tracking-tight max-w-[380px] ${firstArtistId ? "cursor-pointer" : ""}`}
+                onClick={() =>
+                  firstArtistId &&
+                  onNavigateToArtist &&
+                  onNavigateToArtist(firstArtistId, "artist")
+                }
+              >
+                {artistName}
+              </h4></>}
           </div>
 
           {!showLyrics ? (
@@ -745,7 +762,7 @@ export default function NowPlaying({
           ) : (
             <div className="flex-1 flex flex-col h-[280px]">
               <div
-                className="flex-1 text-left overflow-y-auto h-[280px] w-[380px] transform-gpu will-change-scroll"
+                className="flex-1 text-left overflow-y-auto h-[280px] w-[450px] transform-gpu will-change-scroll"
                 ref={lyricsContainerRef}
                 style={{
                   scrollBehavior: "smooth",
@@ -991,8 +1008,8 @@ export default function NowPlaying({
             >
               <div className="py-1">
                 {!isPodcast && (
-                  <MenuItem onClick={toggleLyrics}>
-                    <div className="group flex items-center justify-between px-4 py-[16px] text-sm text-white font-[560] tracking-tight focus:outline-none outline-none">
+                  <MenuItem onClick={toggleLyrics} disabled={!currentPlayback}>
+                    <div className={`group flex items-center justify-between px-4 py-[16px] text-sm ${currentPlayback ? "text-white" : "text-white/50"} font-[560] tracking-tight focus:outline-none outline-none`}>
                       <span className="text-[28px]">
                         {showLyrics ? "Hide Lyrics" : "Show Lyrics"}
                       </span>

--- a/src/hooks/useLyrics.js
+++ b/src/hooks/useLyrics.js
@@ -319,6 +319,11 @@ export function useLyrics(accessToken, currentPlayback) {
   };
 
   useEffect(() => {
+    if (!currentPlayback || currentPlayback?.item?.type === "episode") {
+      setShowLyrics(false);
+      return;
+    }
+
     if (
       showLyrics &&
       currentPlayback?.item &&


### PR DESCRIPTION
This PR includes a couple of changes that includes a new feature and a bug fix:
- Song info is added in the lyrics screen. This makes the album art smaller to make sure the info still fits well within the space.
  - The title still respects the "Toggle Scrolling Text" option.
- When playback has stopped (or current playback has changed to "Not Playing"), the lyrics screen will be hidden.
  - When there is no current song playing, the "Show Lyrics" button is disabled and the text is greyed out.
- There is currently a bug where if you were to play a podcast episode while the lyric screen is showing, the app will throw an error in console and turn into a black screen. When changing to a podcast episode, the lyrics screen will also be hidden.

Here's a video of the song info in action:
https://github.com/user-attachments/assets/beedb9f5-6b3c-4118-b1d6-a8c4d1d1afcf


