### PR TITLE
feat(ui): show album name under artist on NowPlaying

### DIFF
--- a/src/components/player/NowPlaying.jsx
+++ b/src/components/player/NowPlaying.jsx
@@ -352,6 +352,12 @@ function NowPlaying({
 
     const albumId = hasCurrentItem ? currentPlayback?.item?.album?.id : null;
 
+    const albumName = hasCurrentItem
+      ? currentPlayback.item.type === "episode"
+        ? currentPlayback.item.show?.name || ""
+        : currentPlayback.item.album?.name || ""
+      : "";
+
     const albumImages = hasCurrentItem
       ? currentPlayback.item.type === "episode"
         ? currentPlayback.item.images ||
@@ -365,6 +371,7 @@ function NowPlaying({
     return {
       trackName,
       artistName,
+      albumName,
       albumImages,
       trackId,
       firstArtistId,
@@ -375,6 +382,7 @@ function NowPlaying({
   const {
     trackName,
     artistName,
+    albumName,
     albumImages,
     trackId,
     firstArtistId,
@@ -939,6 +947,18 @@ function NowPlaying({
               >
                 {artistName}
               </h4>
+              {albumName && (
+                <h5
+                  className={`text-[24px] font-[480] text-white/40 truncate tracking-tight max-w-[380px] ${albumId && !isLocalMedia && !isPhoneMedia ? "cursor-pointer" : ""}`}
+                  onClick={() => {
+                    if (albumId && !isLocalMedia && !isPhoneMedia) {
+                      onNavigateToAlbum(albumId, "album");
+                    }
+                  }}
+                >
+                  {albumName}
+                </h5>
+              )}
             </div>
           ) : (
             <div className="flex-1 flex flex-col h-[280px]">


### PR DESCRIPTION
## Summary

The NowPlaying player screen displays the track title and artist row,
but the album name has no dedicated UI element even though it's already
available as `currentPlayback.item.album.name` and forwarded through
the cluster (`metadata.album_title`).

This PR adds a third text row under the artist line that shows the
album name when present, with a click handler that navigates to the
album detail page (consistent with how the artist row navigates to
the artist page).

## Changes

- `trackInfo` memo now derives `albumName`, falling back to
  `item.show.name` for episodes so podcast playback also gets a usable
  third-row label (the show name).
- New `<h5>` rendered under the existing `<h4>` artist row. Hidden
  cleanly when `albumName` is empty (some episode types, or
  non-Spotify sources via connectors that don't populate it).
- Styled smaller (`text-[24px]`) and dimmer (`text-white/40`) than the
  artist line to keep the track → artist → album hierarchy visually
  clear.
- Cursor-pointer + navigation enabled only when an `albumId` exists
  and the source isn't local or phone media (matches the artist row's
  conditions).

## Test plan

- [ ] Play a regular Spotify track → album name appears under the
      artist; tapping it navigates to the album detail page.
- [ ] Play a podcast episode → show name appears in the third row.
- [ ] Play from a non-Spotify connector source where
      `is_phone_media` / local media flags are set → album row appears
      when available, but is non-interactive (no album navigation
      since there's no Spotify album ID).
- [ ] Play a track where `album.name` is empty → no third row renders;
      layout collapses cleanly.
- [ ] Lyrics overlay path is unaffected (only the non-lyrics branch
      was modified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)