### PR TITLE
feat: add idle lock screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -297,6 +297,7 @@ function App() {
   const [activeSection, setActiveSection] = useState("recents");
   const previousSectionRef = useRef("recents");
   const activeSectionRef = useRef(activeSection);
+  const idleLockActiveRef = useRef(false);
 
   useEffect(() => {
     activeSectionRef.current = activeSection;
@@ -1021,6 +1022,35 @@ function App() {
     viewingContent,
   ]);
 
+  const handleIdleLockFromNowPlaying = useCallback(() => {
+    if (activeSectionRef.current !== "nowPlaying") return;
+
+    previousSectionRef.current = "nowPlaying";
+    idleLockActiveRef.current = true;
+
+    activeSectionRef.current = "lock";
+    setActiveSection("lock");
+  }, []);
+
+  const handleCloseLockView = useCallback(() => {
+    idleLockActiveRef.current = false;
+    setActiveSection("recents");
+  }, []);
+
+  useEffect(() => {
+    if (!currentPlayback?.is_playing || !idleLockActiveRef.current) return;
+
+    const isLocked = activeSectionRef.current === "lock";
+    const target = previousSectionRef.current ?? "nowPlaying";
+
+    if (isLocked) {
+      setActiveSection(target);
+      activeSectionRef.current = target;
+    }
+
+    idleLockActiveRef.current = false;
+  }, [currentPlayback?.is_playing]);
+
   useEffect(() => {
     const holdTimerRef = { current: null };
     const longPressTriggeredRef = { current: false };
@@ -1074,10 +1104,12 @@ function App() {
       }
 
       if (activeSectionRef.current === "lock") {
+        idleLockActiveRef.current = false;
         const target = previousSectionRef.current || "recents";
         setActiveSection(target);
         activeSectionRef.current = target;
       } else {
+        idleLockActiveRef.current = false;
         previousSectionRef.current = activeSectionRef.current;
         setActiveSection("lock");
         activeSectionRef.current = "lock";
@@ -1286,6 +1318,7 @@ function App() {
         onNavigateToAlbum={handleNavigateToAlbumFromNowPlaying}
         setIgnoreNextRelease={setIgnoreNextRelease}
         isReceivingNowPlayingUpdates={isReceivingNowPlayingUpdates}
+        onIdleLock={handleIdleLockFromNowPlaying}
       />
     );
   } else if (activeSection === "lock") {
@@ -1294,7 +1327,7 @@ function App() {
         currentPlayback={currentPlayback}
         refreshPlaybackState={refreshPlaybackState}
         updateGradientColors={updateGradientColors}
-        onClose={() => setActiveSection("recents")}
+        onClose={handleCloseLockView}
       />
     );
   } else if (viewingContent) {

--- a/src/components/player/NowPlaying.jsx
+++ b/src/components/player/NowPlaying.jsx
@@ -45,6 +45,8 @@ import {
 } from "../common/icons";
 import { generateRandomString } from "../../utils/helpers";
 
+const IDLE_LOCK_MS = 5 * 60 * 1000;
+
 function NowPlaying({
   currentPlayback,
   playbackProgress,
@@ -55,6 +57,7 @@ function NowPlaying({
   onNavigateToAlbum,
   setIgnoreNextRelease,
   isReceivingNowPlayingUpdates = false,
+  onIdleLock,
 }) {
   const [isLiked, setIsLiked] = useState(false);
   const [isCheckingLike, setIsCheckingLike] = useState(false);
@@ -73,6 +76,7 @@ function NowPlaying({
   const [isStartingPlayback, setIsStartingPlayback] = useState(false);
   const [showDeviceSwitcher, setShowDeviceSwitcher] = useState(false);
 
+  const idleLockActivityHandlerRef = useRef(null);
   const volumeTimerRef = useRef(null);
   const volumeLastAdjustedRef = useRef(0);
   const lastWheelEventRef = useRef(0);
@@ -454,6 +458,8 @@ function NowPlaying({
 
   const handleWheel = useCallback(
     (e) => {
+      idleLockActivityHandlerRef.current?.();
+
       if (
         settings.knobSeeksPlaybackEnabled &&
         !isPhoneMedia &&
@@ -625,6 +631,64 @@ function NowPlaying({
     onSwipeDown: handleSwipeDown,
     isActive: true,
   });
+
+  const isPlayingRef = useRef(currentPlayback?.is_playing);
+  isPlayingRef.current = currentPlayback?.is_playing;
+
+  useEffect(() => {
+    if (
+      !settings.idleLockEnabled ||
+      currentPlayback?.is_playing ||
+      !onIdleLock
+    ) {
+      return;
+    }
+
+    let lastActivity = Date.now();
+    let timeoutId = null;
+
+    const schedule = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      const remaining = IDLE_LOCK_MS - (Date.now() - lastActivity);
+      timeoutId = setTimeout(
+        () => {
+          if (!isPlayingRef.current) onIdleLock();
+        },
+        Math.max(0, remaining),
+      );
+    };
+
+    const markActivity = () => {
+      lastActivity = Date.now();
+      schedule();
+    };
+
+    idleLockActivityHandlerRef.current = markActivity;
+
+    const events = [
+      ["pointerdown", document, { capture: true, passive: true }],
+      ["touchstart", document, { capture: true, passive: true }],
+      ["click", document, { capture: true, passive: true }],
+      ["wheel", document, { capture: true, passive: true }],
+      ["keydown", window, { capture: true }],
+    ];
+
+    schedule();
+
+    events.forEach(([event, target, options]) => {
+      target.addEventListener(event, markActivity, options);
+    });
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      if (idleLockActivityHandlerRef.current === markActivity) {
+        idleLockActivityHandlerRef.current = null;
+      }
+      events.forEach(([event, target, options]) => {
+        target.removeEventListener(event, markActivity, options);
+      });
+    };
+  }, [settings.idleLockEnabled, currentPlayback?.is_playing, onIdleLock]);
 
   useEffect(() => {
     if (isLocalMedia || isPhoneMedia) {

--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -64,6 +64,15 @@ const settingsStructure = {
         defaultValue: false,
       },
       {
+        id: "idle-lock",
+        title: "Idle lock screen",
+        type: "toggle",
+        description:
+          "Lock Now Playing after 5 minutes idle while paused. Returns on resume.",
+        storageKey: "idleLockEnabled",
+        defaultValue: false,
+      },
+      {
         id: "show-status-bar",
         title: "Toggle Status Bar",
         type: "toggle",
@@ -179,15 +188,6 @@ const settingsStructure = {
         description:
           "Use the knob to seek through playback instead of controlling volume.",
         storageKey: "knobSeeksPlaybackEnabled",
-        defaultValue: false,
-      },
-      {
-        id: "idle-lock",
-        title: "Idle lock screen",
-        type: "toggle",
-        description:
-          "Lock Now Playing after 5 minutes idle while paused. Returns on resume.",
-        storageKey: "idleLockEnabled",
         defaultValue: false,
       },
     ],

--- a/src/components/settings/Settings.jsx
+++ b/src/components/settings/Settings.jsx
@@ -181,6 +181,15 @@ const settingsStructure = {
         storageKey: "knobSeeksPlaybackEnabled",
         defaultValue: false,
       },
+      {
+        id: "idle-lock",
+        title: "Idle lock screen",
+        type: "toggle",
+        description:
+          "Lock Now Playing after 5 minutes idle while paused. Returns on resume.",
+        storageKey: "idleLockEnabled",
+        defaultValue: false,
+      },
     ],
   },
   credits: {

--- a/src/contexts/SettingsContext.jsx
+++ b/src/contexts/SettingsContext.jsx
@@ -44,6 +44,7 @@ export function SettingsProvider({ children }) {
     ),
     lyricsMenuEnabled: getDefaultSettingValue("lyricsMenuEnabled", true),
     elapsedTimeEnabled: getDefaultSettingValue("elapsedTimeEnabled", false),
+    idleLockEnabled: getDefaultSettingValue("idleLockEnabled", false),
     remainingTimeEnabled: getDefaultSettingValue("remainingTimeEnabled", false),
     showStatusBar: getDefaultSettingValue("showStatusBar", true),
     startWithNowPlaying: getDefaultSettingValue("startWithNowPlaying", true),


### PR DESCRIPTION
I use Nocturne with Nocturne Connector on my desk, where playback can stay paused for long stretches. This PR adds an optional idle lock setting so Now Playing can fall back to the lock screen when paused and untouched.

- Adds a Playback setting to enable the idle lock screen
- Shows the lock screen after Now Playing is idle for 5 minutes while playback is paused
- Resets the idle timer on touch, dial/wheel, click, and key interactions
- Differentiates idle-triggered locks from manually triggered locks
- Keeps manual locks on the lock screen when playback resumes